### PR TITLE
fix: Improve documentation archive creation with robust file finding

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,15 +25,29 @@ jobs:
             -destination 'platform=macOS' \
             -derivedDataPath ./DerivedData
 
-          # Find and copy the generated .doccarchive
-          find ./DerivedData -name "ARCDevTools.doccarchive" -exec cp -R {} ./docs \;
-
       - name: Create documentation archive
         run: |
-          # Create zip to avoid issues with special characters in filenames
-          cd docs
-          zip -r ../documentation.zip ARCDevTools.doccarchive
-          cd ..
+          # Find the .doccarchive (more robust approach)
+          DOCC_ARCHIVE=$(find ./DerivedData -name "*.doccarchive" -type d -print -quit)
+
+          if [ -z "$DOCC_ARCHIVE" ]; then
+            echo "❌ Error: .doccarchive not found"
+            echo "Searching for any .docc files:"
+            find ./DerivedData -name "*.docc*" -ls
+            exit 1
+          fi
+
+          echo "✅ Found documentation archive: $DOCC_ARCHIVE"
+
+          # Create zip directly from the found archive location
+          ARCHIVE_DIR=$(dirname "$DOCC_ARCHIVE")
+          ARCHIVE_NAME=$(basename "$DOCC_ARCHIVE")
+
+          cd "$ARCHIVE_DIR"
+          zip -r "$GITHUB_WORKSPACE/documentation.zip" "$ARCHIVE_NAME"
+
+          echo "✅ Created documentation.zip"
+          ls -lh "$GITHUB_WORKSPACE/documentation.zip"
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Fix Documentation Archive Creation

This PR fixes the persistent "zip warning: name not matched" error in the documentation workflow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Issue Fixed

### Documentation Zip Creation - File Not Found ❌

**Problem:**
```
zip warning: name not matched: ARCDevTools.doccarchive
zip error: Nothing to do!
Error: Process completed with exit code 12
```

**Root Cause Analysis:**

The previous approach had a flaw:
```bash
# Step 1: Try to copy (but this might fail silently)
find ./DerivedData -name "ARCDevTools.doccarchive" -exec cp -R {} ./docs \;

# Step 2: Assume file is in docs/ (it's not!)
cd docs
zip -r ../documentation.zip ARCDevTools.doccarchive  # ❌ FAILS
```

**Why it failed:**
1. The `find ... -exec cp` doesn't report errors if it fails
2. We never verified the file was copied successfully
3. We assumed a specific filename (`ARCDevTools.doccarchive`) but didn't verify it exists
4. The intermediate copy step was unnecessary and error-prone

## Solution

**New robust approach:**

```bash
# 1. Find the .doccarchive reliably
DOCC_ARCHIVE=$(find ./DerivedData -name "*.doccarchive" -type d -print -quit)

# 2. Verify it exists (fail fast with helpful error)
if [ -z "$DOCC_ARCHIVE" ]; then
  echo "❌ Error: .doccarchive not found"
  find ./DerivedData -name "*.docc*" -ls  # Debug info
  exit 1
fi

# 3. Create zip DIRECTLY from where it was built
ARCHIVE_DIR=$(dirname "$DOCC_ARCHIVE")
ARCHIVE_NAME=$(basename "$DOCC_ARCHIVE")

cd "$ARCHIVE_DIR"
zip -r "$GITHUB_WORKSPACE/documentation.zip" "$ARCHIVE_NAME"
```

**Benefits:**
- ✅ No intermediate copy step (one less thing to fail)
- ✅ Explicit error checking with debugging output
- ✅ Works regardless of actual archive name
- ✅ Uses `$GITHUB_WORKSPACE` for consistent paths
- ✅ Single source of truth (zip from original location)

## Changes Made

### Modified Files
- `.github/workflows/docs.yml`
  - Removed docs/ directory copy step
  - Added robust find with error handling
  - Create zip directly from DerivedData location
  - Added debugging output for troubleshooting

## Testing Strategy

The new approach will:
1. Find any `.doccarchive` in DerivedData (not hardcoded name)
2. Fail immediately with helpful error if not found
3. Create zip from verified location
4. Show file size and location for debugging

## Expected Behavior

**Success case:**
```
✅ Found documentation archive: ./DerivedData/.../ARCDevTools.doccarchive
✅ Created documentation.zip
-rw-r--r-- 1 runner docker 1.2M documentation.zip
```

**Failure case (with debugging):**
```
❌ Error: .doccarchive not found
Searching for any .docc files:
[list of files in DerivedData]
```

## Post-Merge

After merging and deploying to main:
- Documentation workflow should complete successfully
- Artifact will upload correctly
- GitHub Pages deployment will work

## Checklist

- [x] Robust file finding with error handling
- [x] Removed error-prone intermediate copy
- [x] Added debugging output
- [x] Simplified workflow logic
- [x] Tested approach logic