### PR TITLE
chore(release): prepare v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.11.0] - 2026-03-21
+
+### Changed
+- **ARCKnowledge submodule** updated to v2.11.0
+
+---
+
 ## [2.10.0] - 2026-03-20
 
 ### Changed


### PR DESCRIPTION
## Summary
- Updates CHANGELOG.md with v2.11.0 release entry
- ARCKnowledge submodule updated to v2.11.0

## Changes
- `chore(deps)`: ARCKnowledge submodule → v2.11.0

## Type
- [ ] feat
- [ ] fix
- [x] chore