### PR TITLE
chore(release): prepare v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.12.0] - 2026-03-24
+
+### Changed
+- **ARCKnowledge submodule** updated to v2.12.0
+
+---
+
 ## [2.11.0] - 2026-03-21
 
 ### Changed


### PR DESCRIPTION
## Release v2.12.0

### Changed
- **ARCKnowledge submodule** updated to v2.12.0

---

*Auto-generated release PR by `/arc-release`*