### PR TITLE
chore(release): prepare v2.13.0 (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.13.0] - 2026-03-25
+
+### Changed
+- **ARCKnowledge submodule** updated to v2.13.0
+
+---
+
 ## [2.12.0] - 2026-03-24
 
 ### Changed


### PR DESCRIPTION
## Summary
- Update CHANGELOG.md for v2.13.0 release
- ARCKnowledge submodule updated to v2.13.0

## Test plan
- [ ] Verify CHANGELOG.md is correct
- [ ] Tag v2.13.0 after merge