### PR TITLE
chore: sync develop with main after v2.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.13.0] - 2026-03-25
+
+### Changed
+- **ARCKnowledge submodule** updated to v2.13.0
+
+---
+
 ## [2.12.0] - 2026-03-24
 
 ### Changed


### PR DESCRIPTION
## Summary
- Sync develop branch with main after v2.13.0 release
- Includes CHANGELOG.md update for v2.13.0