### PR TITLE
chore(release): prepare v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.13.1] - 2026-03-28
+
+### Changed
+- **ARCKnowledge submodule** updated to v2.13.1 (12 new agents, 3 new skills, Monetization section, swift-design-principles, localization standards)
+
+---
+
 ## [2.13.0] - 2026-03-25
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v2.13.1
- ARCKnowledge submodule bumped to v2.13.1

## Changes in ARCKnowledge v2.13.1

- 🤖 12 new Claude Code agents (`arc-aso`, `arc-swift-tdd`, `arc-swift-reviewer`, `arc-swiftdata-migration`, `arc-testflight`, `arc-xcode-explorer`, `arc-spm-manager`, `arc-dependency-auditor`, `arc-pr-publisher`, `arc-release-orchestrator`, `arc-linear-bridge`, `arc-swift-debugger`)
- 📚 3 new skills (`arc-localization`, `arc-xcode-cloud`, `arc-final-review`)
- 💰 New `Monetization/` section (integration guide, paywall patterns, pricing strategy)
- 🏗️ New `Architecture/swift-design-principles.md` and SOLID docs
- 📋 New `AGENTS.md` index
- 📖 `Quality/localization.md` standards

## Test plan

- [ ] Verify CHANGELOG.md entry is correct
- [ ] Verify ARCKnowledge submodule points to v2.13.1