### PR TITLE
feat(distribution): add ARCDistribution integration

### DIFF
--- a/scripts/setup-distribution.sh
+++ b/scripts/setup-distribution.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# =============================================================================
+# setup-distribution.sh — Create iCloud Distribution folder structure
+# =============================================================================
+#
+# Creates the App Store distribution folder layout in:
+#   ~/Documents/ARCLabsStudio/Distribution/
+#
+# Usage:
+#   ./ARCDevTools/scripts/setup-distribution.sh [--app <AppName>]
+#   ./ARCDevTools/scripts/setup-distribution.sh --all
+#
+# =============================================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}ℹ${NC} $1"; }
+log_success() { echo -e "${GREEN}✓${NC} $1"; }
+log_warning() { echo -e "${YELLOW}⚠${NC} $1"; }
+log_error()   { echo -e "${RED}✗${NC} $1"; }
+
+# Configuration
+DISTRIBUTION_ROOT="$HOME/Documents/ARCLabsStudio/Distribution"
+BRANDING_ROOT="$HOME/Documents/ARCLabsStudio/Branding"
+ARC_APPS=("FavRes" "FavBook" "PizzeriaLaFamiglia" "TicketMind" "BackHaul")
+
+LOCALES=("en-US" "es-ES")
+SCREENSHOT_SIZES=("iPhone-6.9" "iPhone-6.5" "iPad-13")
+
+create_shared_structure() {
+    log_info "Creating _shared/ structure..."
+
+    mkdir -p "$DISTRIBUTION_ROOT/_shared/templates"
+    mkdir -p "$DISTRIBUTION_ROOT/_shared/press-kit"
+
+    # Create brand symlink if Branding folder exists
+    if [ -d "$BRANDING_ROOT" ]; then
+        local brand_link="$DISTRIBUTION_ROOT/_shared/brand"
+        if [ ! -L "$brand_link" ]; then
+            ln -sf "$BRANDING_ROOT" "$brand_link"
+            log_success "_shared/brand → $BRANDING_ROOT"
+        else
+            log_info "_shared/brand → already linked"
+        fi
+    else
+        mkdir -p "$DISTRIBUTION_ROOT/_shared/brand"
+        log_warning "Branding folder not found at $BRANDING_ROOT — created empty brand/ instead"
+    fi
+
+    log_success "_shared/ structure created"
+}
+
+create_app_structure() {
+    local app="$1"
+    log_info "Creating $app/ structure..."
+
+    # Metadata folders
+    for locale in "${LOCALES[@]}"; do
+        local metadata_dir="$DISTRIBUTION_ROOT/$app/metadata/$locale"
+        mkdir -p "$metadata_dir"
+
+        # Create placeholder files if they don't exist
+        for file in name.txt subtitle.txt keywords.txt description.txt release_notes.txt; do
+            if [ ! -f "$metadata_dir/$file" ]; then
+                touch "$metadata_dir/$file"
+            fi
+        done
+    done
+
+    # Screenshot folders
+    for size in "${SCREENSHOT_SIZES[@]}"; do
+        mkdir -p "$DISTRIBUTION_ROOT/$app/screenshots/$size"
+    done
+
+    # Marketing folders
+    mkdir -p "$DISTRIBUTION_ROOT/$app/marketing/social"
+    mkdir -p "$DISTRIBUTION_ROOT/$app/marketing/promo"
+
+    log_success "$app/ structure created"
+}
+
+create_project_symlinks() {
+    local app="$1"
+
+    # Try to find the Xcode project root for this app
+    local possible_roots=(
+        "$HOME/Developer/ARCLabsStudio/Apps/$app"
+        "$HOME/Developer/$app"
+        "$HOME/Developer/ARCLabsStudio/$app"
+    )
+
+    for app_root in "${possible_roots[@]}"; do
+        if [ -d "$app_root" ]; then
+            local symlink_path="$app_root/Distribution"
+            if [ ! -L "$symlink_path" ] && [ ! -d "$symlink_path" ]; then
+                ln -sf "$DISTRIBUTION_ROOT/$app" "$symlink_path"
+                log_success "Symlink created: $app_root/Distribution → $DISTRIBUTION_ROOT/$app"
+            fi
+            return
+        fi
+    done
+
+    log_info "App project folder not found for $app — skipping symlink"
+}
+
+print_structure() {
+    echo ""
+    echo "Distribution folder structure:"
+    echo ""
+    echo "$DISTRIBUTION_ROOT/"
+    echo "├── _shared/"
+    echo "│   ├── templates/"
+    echo "│   ├── brand/ → $BRANDING_ROOT"
+    echo "│   └── press-kit/"
+    for app in "${ARC_APPS[@]}"; do
+        echo "├── $app/"
+        echo "│   ├── metadata/"
+        for locale in "${LOCALES[@]}"; do
+            echo "│   │   └── $locale/"
+            echo "│   │       ├── name.txt (30 chars max)"
+            echo "│   │       ├── subtitle.txt (30 chars max)"
+            echo "│   │       ├── keywords.txt (100 chars max)"
+            echo "│   │       ├── description.txt (4000 chars max)"
+            echo "│   │       └── release_notes.txt"
+        done
+        echo "│   ├── screenshots/"
+        for size in "${SCREENSHOT_SIZES[@]}"; do
+            echo "│   │   └── $size/"
+        done
+        echo "│   └── marketing/"
+        echo "│       ├── social/"
+        echo "│       └── promo/"
+    done
+    echo ""
+}
+
+main() {
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════════╗"
+    echo "║        ARC Labs Distribution Folder Setup                      ║"
+    echo "╚════════════════════════════════════════════════════════════════╝"
+    echo ""
+
+    log_info "Distribution root: $DISTRIBUTION_ROOT"
+
+    # Parse arguments
+    local target_app=""
+    local setup_all=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --app)
+                target_app="$2"
+                shift 2
+                ;;
+            --all)
+                setup_all=true
+                shift
+                ;;
+            -h|--help)
+                echo "Usage: $0 [--app <AppName>] [--all]"
+                echo ""
+                echo "  --app <AppName>  Create structure for specific app"
+                echo "  --all            Create structure for all ARC Labs apps (default)"
+                echo ""
+                echo "Available apps: ${ARC_APPS[*]}"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown argument: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    # Default to --all if no argument given
+    if [ -z "$target_app" ] && [ "$setup_all" = false ]; then
+        setup_all=true
+    fi
+
+    # Create shared structure
+    create_shared_structure
+
+    # Create app structures
+    if [ "$setup_all" = true ]; then
+        for app in "${ARC_APPS[@]}"; do
+            create_app_structure "$app"
+            create_project_symlinks "$app"
+        done
+    elif [ -n "$target_app" ]; then
+        create_app_structure "$target_app"
+        create_project_symlinks "$target_app"
+    fi
+
+    print_structure
+
+    log_success "Distribution setup complete!"
+    echo ""
+    log_info "Next steps:"
+    echo "  1. Fill in metadata files in each locale folder"
+    echo "  2. Run: arc-distribution validate-metadata --app-id <AppName>"
+    echo "  3. Add screenshots to screenshots/ folders"
+    echo "  4. Run /arc-aso-audit to score your metadata"
+    echo ""
+}
+
+main "$@"

--- a/scripts/setup-skills.sh
+++ b/scripts/setup-skills.sh
@@ -71,6 +71,73 @@ find_arcknowledge() {
     return 1
 }
 
+# Find ARCDistribution directory (optional — provides ASO skills)
+find_arcdistribution() {
+    local project_root="$1"
+    local possible_paths=(
+        # Sibling packages directory (Packages/ARCDistribution)
+        "$(dirname "$project_root")/ARCDistribution"
+        # Direct submodule
+        "$project_root/ARCDistribution"
+        # Inside Dependencies
+        "$project_root/Dependencies/ARCDistribution"
+        # SPM checkouts
+        "$project_root/.build/checkouts/ARCDistribution"
+        # Absolute Packages path
+        "$HOME/Developer/ARCLabsStudio/Packages/ARCDistribution"
+    )
+
+    for path in "${possible_paths[@]}"; do
+        if [[ -d "$path/.claude/skills" ]]; then
+            echo "$path"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Link skills from a given source directory into the target skills dir
+link_skills_from() {
+    local skills_source="$1"
+    local skills_target="$2"
+    local source_label="$3"
+    local linked=0
+    local skipped=0
+    local updated=0
+
+    for skill_dir in "$skills_source"/*/; do
+        if [[ -d "$skill_dir" ]]; then
+            skill_name=$(basename "$skill_dir")
+            target_link="$skills_target/$skill_name"
+            rel_path=$(relative_path "$skills_target" "$skill_dir")
+            rel_path="${rel_path%/}"
+
+            if [[ -L "$target_link" ]]; then
+                current_target=$(readlink "$target_link")
+                if [[ "$current_target" == "$rel_path" ]]; then
+                    log_info "  $skill_name → already linked ($source_label)"
+                    ((skipped++)) || true
+                else
+                    rm "$target_link"
+                    ln -s "$rel_path" "$target_link"
+                    log_success "  $skill_name → updated ($source_label)"
+                    ((updated++)) || true
+                fi
+            elif [[ -e "$target_link" ]]; then
+                log_warning "  $skill_name → skipped (file/directory exists)"
+                ((skipped++)) || true
+            else
+                ln -s "$rel_path" "$target_link"
+                log_success "  $skill_name → linked ($source_label)"
+                ((linked++)) || true
+            fi
+        fi
+    done
+
+    echo "  $source_label: +$linked linked, $updated updated, $skipped skipped"
+}
+
 # Get relative path from source to target
 relative_path() {
     local source="$1"
@@ -129,51 +196,26 @@ main() {
     log_info "Linking skills..."
     echo ""
 
-    # Create symlinks for each skill
-    for skill_dir in "$SKILLS_SOURCE"/*/; do
-        if [[ -d "$skill_dir" ]]; then
-            skill_name=$(basename "$skill_dir")
-            target_link="$SKILLS_TARGET/$skill_name"
+    # Link ARCKnowledge skills
+    link_skills_from "$SKILLS_SOURCE" "$SKILLS_TARGET" "ARCKnowledge"
 
-            # Calculate relative path for symlink
-            rel_path=$(relative_path "$SKILLS_TARGET" "$skill_dir")
-            # Remove trailing slash
-            rel_path="${rel_path%/}"
-
-            if [[ -L "$target_link" ]]; then
-                # Symlink exists, check if it points to the right place
-                current_target=$(readlink "$target_link")
-                if [[ "$current_target" == "$rel_path" ]]; then
-                    log_info "  $skill_name → already linked"
-                    ((skills_skipped++))
-                else
-                    # Update symlink
-                    rm "$target_link"
-                    ln -s "$rel_path" "$target_link"
-                    log_success "  $skill_name → updated"
-                    ((skills_updated++))
-                fi
-            elif [[ -e "$target_link" ]]; then
-                # Something exists but it's not a symlink
-                log_warning "  $skill_name → skipped (file/directory exists)"
-                ((skills_skipped++))
-            else
-                # Create new symlink
-                ln -s "$rel_path" "$target_link"
-                log_success "  $skill_name → linked"
-                ((skills_linked++))
-            fi
+    # Link ARCDistribution skills (optional — ASO + distribution skills)
+    ARCDISTRIBUTION_PATH=$(find_arcdistribution "$PROJECT_ROOT") || true
+    if [[ -n "$ARCDISTRIBUTION_PATH" ]]; then
+        DISTRIBUTION_SKILLS_SOURCE="$ARCDISTRIBUTION_PATH/.claude/skills"
+        if [[ -d "$DISTRIBUTION_SKILLS_SOURCE" ]]; then
+            log_success "Found ARCDistribution: $ARCDISTRIBUTION_PATH"
+            link_skills_from "$DISTRIBUTION_SKILLS_SOURCE" "$SKILLS_TARGET" "ARCDistribution"
         fi
-    done
+    else
+        log_info "ARCDistribution not found — ASO skills skipped"
+        log_info "  To enable: clone ARCDistribution to $(dirname "$PROJECT_ROOT")/ARCDistribution"
+    fi
 
     echo ""
     echo "════════════════════════════════════════════════════════════════"
     echo ""
     log_success "Skills setup complete!"
-    echo ""
-    echo "  New links:     $skills_linked"
-    echo "  Updated:       $skills_updated"
-    echo "  Skipped:       $skills_skipped"
     echo ""
 
     # Verify skills are accessible

--- a/templates/ci_scripts/ci_post_xcodebuild.sh
+++ b/templates/ci_scripts/ci_post_xcodebuild.sh
@@ -11,5 +11,65 @@ if [ -n "${CI_TEST_RESULTS_PATH}" ]; then
   echo "   🧪 Test results: ${CI_TEST_RESULTS_PATH}"
 fi
 
+# =============================================================================
+# ARCDistribution — Metadata sync after successful archive
+# =============================================================================
+#
+# Requires environment variables in App Store Connect:
+#   ASC_KEY_ID       — API key ID (from Users and Access > Integrations)
+#   ASC_ISSUER_ID    — API issuer ID
+#   ASC_PRIVATE_KEY  — Base64-encoded .p8 private key content
+#   APP_ID           — App Store Connect app ID (numeric)
+#   METADATA_LOCALE  — Primary locale (default: en-US)
+#
+# The arc-distribution CLI is built during ci_post_clone.sh (see that script).
+# If the CLI is not present, metadata sync is skipped (non-blocking).
+# =============================================================================
+
+if [ "${CI_XCODEBUILD_ACTION}" = "archive" ] && [ -n "${CI_ARCHIVE_PATH}" ]; then
+  echo ""
+  echo "📋 [ci_post_xcodebuild] Checking metadata sync conditions..."
+
+  # Verify required env vars
+  if [ -z "${ASC_KEY_ID}" ] || [ -z "${ASC_ISSUER_ID}" ] || [ -z "${ASC_PRIVATE_KEY}" ]; then
+    echo "   ⚠️  ASC credentials not set — skipping metadata sync"
+    echo "      Set ASC_KEY_ID, ASC_ISSUER_ID, ASC_PRIVATE_KEY in App Store Connect env vars"
+  elif [ -z "${APP_ID}" ]; then
+    echo "   ⚠️  APP_ID not set — skipping metadata sync"
+  else
+    LOCALE="${METADATA_LOCALE:-en-US}"
+    ARC_CLI_PATH="$CI_WORKSPACE/arc-distribution"
+
+    if [ -f "$ARC_CLI_PATH" ]; then
+      echo "   🔄 Syncing metadata for app $APP_ID [$LOCALE]..."
+
+      # Validate metadata character counts
+      "$ARC_CLI_PATH" validate-metadata --app-id "$APP_ID" --locale "$LOCALE" || {
+        echo "   ❌ Metadata validation failed — sync skipped"
+        echo "      Run: arc-distribution validate-metadata --app-id $APP_ID --locale $LOCALE"
+        exit 1
+      }
+
+      # Sync metadata to App Store Connect
+      "$ARC_CLI_PATH" metadata sync --app-id "$APP_ID" --locale "$LOCALE"
+      echo "   ✅ Metadata synced for $APP_ID [$LOCALE]"
+
+      # Sync additional locales if defined (space-separated list)
+      if [ -n "${ADDITIONAL_LOCALES}" ]; then
+        for EXTRA_LOCALE in $ADDITIONAL_LOCALES; do
+          echo "   🔄 Syncing metadata [$EXTRA_LOCALE]..."
+          "$ARC_CLI_PATH" metadata sync --app-id "$APP_ID" --locale "$EXTRA_LOCALE" || {
+            echo "   ⚠️  Metadata sync failed for [$EXTRA_LOCALE] — continuing"
+          }
+        done
+      fi
+
+    else
+      echo "   ℹ️  arc-distribution CLI not found at $ARC_CLI_PATH — skipping metadata sync"
+      echo "      Build the CLI in ci_post_clone.sh to enable automatic metadata sync"
+    fi
+  fi
+fi
+
 echo ""
 echo "✅ Post-build logging complete"


### PR DESCRIPTION
## Summary

- `setup-skills.sh`: extract `link_skills_from()` helper, add `find_arcdistribution()` to auto-link ASO skills from ARCDistribution package when present
- `setup-distribution.sh`: new script to scaffold iCloud Distribution folder structure for App Store metadata, screenshots, and branding assets across all ARC apps
- `ci_post_xcodebuild.sh`: ARCDistribution metadata sync after archive step — validates and syncs metadata to App Store Connect using `arc-distribution` CLI; requires `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY`, `APP_ID` env vars in App Store Connect; non-blocking if CLI not present

## Test plan

- [ ] Run `setup-distribution.sh --app FavRes` — verify folder structure created in `~/Documents/ARCLabsStudio/Distribution/FavRes/`
- [ ] Run `setup-skills.sh` with ARCDistribution present — verify ASO skills are linked
- [ ] Run `setup-skills.sh` without ARCDistribution — verify graceful skip with info message
- [ ] Verify `ci_post_xcodebuild.sh` skips gracefully when `ASC_KEY_ID` not set