### PR TITLE
feat(scripts): add check-localization.py for String Catalog completeness

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,6 +105,51 @@ Installs Claude Code skills for ARCDevTools workflows.
 
 ---
 
+### `check-localization.py`
+
+Checks String Catalog (`*.xcstrings`) completeness for required locales. Fails (exit 1) when any key is missing a translation or is in `new` / `needs_review` state.
+
+Auto-discovers all `.xcstrings` files from the working directory (skipping `.build`, `DerivedData`, `Pods`, `node_modules`, `.swiftpm`, `.git`). Pass `--catalog` to scope to a single file.
+
+**Usage:**
+
+```bash
+# Auto-discover all catalogs, require Spanish (default)
+python3 ARCDevTools/scripts/check-localization.py
+
+# Single catalog, multiple required locales
+python3 ARCDevTools/scripts/check-localization.py \
+    --catalog Sources/Resources/Localizable.xcstrings \
+    --locales es,fr,de
+
+# List all catalogs (even on success)
+python3 ARCDevTools/scripts/check-localization.py --verbose
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--locales` | `es` | Comma-separated required locales |
+| `--catalog` | (auto-discover) | Path to a single `.xcstrings` file |
+| `--verbose` | off | Show all checked catalogs even on success |
+
+**Wire into Makefile:**
+
+```makefile
+lint-l10n:
+	@python3 ARCDevTools/scripts/check-localization.py \
+		--catalog Path/To/Localizable.xcstrings \
+		--locales es
+
+lint: lint-l10n
+	# ... existing lint steps
+```
+
+**Requirements:** Python 3.9+ (uses `Path.is_relative_to`, type hints, `from __future__ import annotations`).
+
+---
+
 ## GitHub Actions Scripts
 
 See `scripts/github-actions/README.md` for automation scripts related to GitHub Actions workflows.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -109,7 +109,13 @@ Installs Claude Code skills for ARCDevTools workflows.
 
 Checks String Catalog (`*.xcstrings`) completeness for required locales. Fails (exit 1) when any key is missing a translation or is in `new` / `needs_review` state.
 
-Auto-discovers all `.xcstrings` files from the working directory (skipping `.build`, `DerivedData`, `Pods`, `node_modules`, `.swiftpm`, `.git`). Pass `--catalog` to scope to a single file.
+Auto-discovers all `.xcstrings` files from the working directory (skipping `.build`, `Build`, `DerivedData`, `Pods`, `Carthage`, `node_modules`, `.swiftpm`, `.git`). Pass `--catalog` to scope to a single file.
+
+**When to use:**
+
+- **iOS apps with String Catalogs** — add `lint-l10n` to your Makefile (see below). Wire it into `lint:` so CI catches missing translations.
+- **SPM packages** — skip this script. ARC packages are text-agnostic: they use `LocalizedStringKey` literals with English defaults; the consuming app's String Catalog resolves translations. Running the script in a package project is safe (exits 0 silently when no catalogs are found), but there is nothing to check.
+- **Unsure?** — run bare with no flags. If no `.xcstrings` files exist, the script exits 0 and does nothing.
 
 **Usage:**
 

--- a/scripts/check-localization.py
+++ b/scripts/check-localization.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Check String Catalog completeness for required locales.
+
+Usage:
+    check-localization.py [--locales es,fr] [--catalog PATH] [--verbose]
+
+Auto-discovers `*.xcstrings` files from the working directory (skipping `.build`,
+`DerivedData`, `Pods`, `node_modules`, `.git`). Pass `--catalog` to check a single
+file. Fails with non-zero exit code if any string in any catalog is missing a
+required locale or is in `new` / `needs_review` state.
+
+Defaults:
+    --locales es
+    --catalog (auto-discover)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+BAD_STATES = {"new", "needs_review"}
+SKIP_DIRS = {".build", "DerivedData", "Pods", "node_modules", ".git", ".swiftpm"}
+
+
+def discover_catalogs(root: Path) -> list[Path]:
+    found: list[Path] = []
+    for path in root.rglob("*.xcstrings"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        found.append(path)
+    return sorted(found)
+
+
+def check_catalog(path: Path, locales: list[str]) -> tuple[int, list[str]]:
+    """Return (failure_count, error_messages)."""
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return 1, [f"   ✗ failed to parse: {exc}"]
+
+    strings = data.get("strings", {})
+    if not strings:
+        return 0, [f"   (empty catalog, skipping)"]
+
+    failures: list[str] = []
+    for locale in locales:
+        missing: list[str] = []
+        bad_state: list[tuple[str, str]] = []
+        for key, entry in strings.items():
+            locs = entry.get("localizations", {})
+            if locale not in locs:
+                missing.append(key)
+            else:
+                state = locs[locale].get("stringUnit", {}).get("state", "")
+                if state in BAD_STATES:
+                    bad_state.append((key, state))
+
+        if missing:
+            failures.append(f"   ✗ [{locale}] {len(missing)} key(s) missing translation:")
+            failures.extend(f"      • {k!r}" for k in missing)
+        if bad_state:
+            failures.append(f"   ✗ [{locale}] {len(bad_state)} key(s) with incomplete state:")
+            failures.extend(f"      • [{s}] {k!r}" for k, s in bad_state)
+
+    if not failures:
+        n = len(strings)
+        loc_str = ", ".join(locales)
+        return 0, [f"   ✓ {n} key(s) complete for: {loc_str}"]
+
+    return len(failures), failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--locales", default="es", help="Comma-separated required locales (default: es)")
+    parser.add_argument("--catalog", type=Path, help="Path to a single .xcstrings file (skips auto-discovery)")
+    parser.add_argument("--verbose", action="store_true", help="List all checked catalogs even on success")
+    args = parser.parse_args()
+
+    locales = [loc.strip() for loc in args.locales.split(",") if loc.strip()]
+    if not locales:
+        print("error: --locales must be non-empty", file=sys.stderr)
+        return 1
+
+    if args.catalog:
+        if not args.catalog.exists():
+            print(f"error: catalog not found: {args.catalog}", file=sys.stderr)
+            return 1
+        catalogs = [args.catalog]
+    else:
+        catalogs = discover_catalogs(Path.cwd())
+        if not catalogs:
+            print("error: no .xcstrings files found", file=sys.stderr)
+            return 1
+
+    total_failures = 0
+    for path in catalogs:
+        rel = path.relative_to(Path.cwd()) if path.is_relative_to(Path.cwd()) else path
+        count, msgs = check_catalog(path, locales)
+        total_failures += count
+        if count > 0 or args.verbose:
+            print(f"\n{rel}")
+            for msg in msgs:
+                print(msg)
+
+    if total_failures == 0:
+        loc_str = ", ".join(locales)
+        print(f"\n✅ All {len(catalogs)} catalog(s) complete for: {loc_str}")
+        return 0
+
+    print(f"\n❌ {total_failures} failure(s) across {len(catalogs)} catalog(s)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-localization.py
+++ b/scripts/check-localization.py
@@ -22,7 +22,7 @@ import sys
 from pathlib import Path
 
 BAD_STATES = {"new", "needs_review"}
-SKIP_DIRS = {".build", "DerivedData", "Pods", "node_modules", ".git", ".swiftpm"}
+SKIP_DIRS = {".build", "Build", "DerivedData", "Pods", "Carthage", "node_modules", ".git", ".swiftpm"}
 
 
 def discover_catalogs(root: Path) -> list[Path]:
@@ -94,8 +94,9 @@ def main() -> int:
     else:
         catalogs = discover_catalogs(Path.cwd())
         if not catalogs:
-            print("error: no .xcstrings files found", file=sys.stderr)
-            return 1
+            if args.verbose:
+                print("No .xcstrings files found — nothing to check.")
+            return 0
 
     total_failures = 0
     for path in catalogs:


### PR DESCRIPTION
## Summary

Generic Python utility for verifying `.xcstrings` files contain translations for all required locales. Fails (exit 1) when keys are missing translations or are in `new` / `needs_review` state.

Originally developed for FavRes-iOS ([FVRS-221](https://linear.app/favres/issue/FVRS-221/localization)); generalized for ARC-wide reuse.

## Features

- Auto-discovers `*.xcstrings` files from cwd (skips `.build`, `DerivedData`, `Pods`, `node_modules`, `.swiftpm`, `.git`)
- `--catalog PATH` for explicit single-file mode
- `--locales es,fr,de` for multi-locale projects (default: `es`)
- `--verbose` to list all checked catalogs
- Zero deps (Python 3.9+ stdlib only)

## Consumer Integration

```makefile
lint-l10n:
	@python3 ARCDevTools/scripts/check-localization.py \
		--catalog Path/To/Localizable.xcstrings \
		--locales es

lint: lint-l10n
	# ... existing lint steps
```

## Test plan

- [x] Tested locally on FavRes-iOS (`make lint-l10n` passes with 409 keys complete)
- [x] Auto-discover correctly skips `.build`, `DerivedData`, `Pods`
- [x] `--catalog` mode scopes to single file
- [x] `--locales es,fr` accepts multi-locale lists
- [x] Exit code 1 when keys missing translation; 0 on success
- [x] Help text correct (`--help`)

## Follow-up

When merged, FavRes-iOS will:
1. Bump submodule pointer to merged SHA
2. Delete local `scripts/check-localization.py` 
3. Update Makefile to call `Tools/ARCDevTools/scripts/check-localization.py`