### PR TITLE
feat(scripts): add notes-system bootstrap and memory prune scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,6 +105,60 @@ Installs Claude Code skills for ARCDevTools workflows.
 
 ---
 
+### `arc-setup-notes-system.sh`
+
+Bootstraps the ARC notes/Obsidian system in any ARC repo. Creates
+`.claude/hooks/setup-notes.sh` (creates the `notes/` symlink to the project's
+Obsidian vault folder) and `.claude/hooks/sync-plans.sh` (Stop hook that
+archives Claude plans). Appends `notes` to `.gitignore`. Idempotent.
+
+**What it does:**
+- Detects project name from `git rev-parse --show-toplevel` (strips
+  `-iOS` / `-Android` / `-Web` / `-macOS` suffix)
+- Writes both hook scripts (skips if already up-to-date)
+- Adds `notes` to `.gitignore` if missing
+- Runs `setup-notes.sh` to create the symlink when the vault folder exists
+- Prints next steps for wiring the hooks into `.claude/settings.local.json`
+
+**Cross-machine safe:** generated hooks resolve `$HOME` at runtime; never
+hardcode the current user. Re-run after every clone or worktree creation.
+
+**Usage:**
+```bash
+./scripts/arc-setup-notes-system.sh                       # auto-detect
+./scripts/arc-setup-notes-system.sh --name FavRes         # explicit name
+./scripts/arc-setup-notes-system.sh --root ~/path --dry-run
+./scripts/arc-setup-notes-system.sh --verbose
+```
+
+---
+
+### `arc-memory-prune.sh`
+
+Audits Claude Code's auto-memory directories
+(`~/.claude/projects/*/memory/`) and reports stale entries (default: not
+modified in more than 60 days). Read-only by default.
+
+**What it does:**
+- Walks every project under `$HOME/.claude/projects/`
+- Color-codes each file by age (green < 30d, yellow 30-60d, red >= 60d)
+- Parses `name:` and `description:` from frontmatter when present
+- Reports per-project totals (file count, stale count, oldest, total size)
+- With `--delete`, prompts per-file before removing (skip prompts with `--yes`)
+
+**Cross-machine safe:** scans only the current user's `~/.claude` tree.
+
+**Usage:**
+```bash
+./scripts/arc-memory-prune.sh                  # report only
+./scripts/arc-memory-prune.sh --days 90        # custom threshold
+./scripts/arc-memory-prune.sh --verbose        # show all files, not just stale
+./scripts/arc-memory-prune.sh --delete         # interactive prune
+./scripts/arc-memory-prune.sh --delete --yes   # non-interactive prune
+```
+
+---
+
 ### `check-localization.py`
 
 Checks String Catalog (`*.xcstrings`) completeness for required locales. Fails (exit 1) when any key is missing a translation or is in `new` / `needs_review` state.

--- a/scripts/arc-memory-prune.sh
+++ b/scripts/arc-memory-prune.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+# =============================================================================
+# arc-memory-prune.sh - Audit Claude Code auto-memory directories
+# =============================================================================
+#
+# Scans ~/.claude/projects/*/memory/ across every project that Claude Code has
+# tracked on this machine and reports stale entries (default: not modified in
+# more than 60 days). Read-only by default; pass --delete to actually remove
+# files (with per-file confirmation unless --yes is also given).
+#
+# Cross-machine safe: walks $HOME/.claude/projects, never the current user's
+# absolute path. Safe to run on any developer machine — it only touches that
+# user's own ~/.claude tree.
+#
+# Usage:
+#   ./ARCDevTools/scripts/arc-memory-prune.sh                    # report only
+#   ./ARCDevTools/scripts/arc-memory-prune.sh --days 90          # custom threshold
+#   ./ARCDevTools/scripts/arc-memory-prune.sh --delete           # interactive prune
+#   ./ARCDevTools/scripts/arc-memory-prune.sh --delete --yes     # non-interactive
+#   ./ARCDevTools/scripts/arc-memory-prune.sh --root /custom     # alternate root
+#
+# Exit codes:
+#   0 — completed successfully (even if stale files were found in report mode)
+#   1 — argument or environment error
+#   2 — user aborted a deletion prompt
+#
+# =============================================================================
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Color output (TTY-aware)
+# -----------------------------------------------------------------------------
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1 && [[ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]]; then
+    C_RED="$(tput setaf 1)"
+    C_GREEN="$(tput setaf 2)"
+    C_YELLOW="$(tput setaf 3)"
+    C_BLUE="$(tput setaf 4)"
+    C_DIM="$(tput dim)"
+    C_BOLD="$(tput bold)"
+    C_RESET="$(tput sgr0)"
+else
+    C_RED=""; C_GREEN=""; C_YELLOW=""; C_BLUE=""; C_DIM=""; C_BOLD=""; C_RESET=""
+fi
+
+log_info()    { echo "${C_BLUE}i${C_RESET} $*"; }
+log_success() { echo "${C_GREEN}OK${C_RESET} $*"; }
+log_warn()    { echo "${C_YELLOW}!!${C_RESET} $*"; }
+log_error()   { echo "${C_RED}xx${C_RESET} $*" >&2; }
+
+# -----------------------------------------------------------------------------
+# Defaults & argument parsing
+# -----------------------------------------------------------------------------
+DAYS=60
+WARN_DAYS=30
+ROOT="$HOME/.claude/projects"
+DO_DELETE=0
+ASSUME_YES=0
+VERBOSE=0
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Audit Claude Code auto-memory directories for stale entries.
+
+Options:
+  --days <N>     Stale threshold in days (default: $DAYS)
+  --warn <N>     Warning threshold in days (default: $WARN_DAYS, yellow)
+  --root <path>  Override scan root (default: \$HOME/.claude/projects)
+  --delete       Delete stale files (prompts unless --yes)
+  --yes          Skip confirmation prompts (use with --delete)
+  --verbose      Show all files, not just stale ones
+  -h, --help     Show this help
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") --days 90
+  $(basename "$0") --delete
+  $(basename "$0") --delete --yes --days 120
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --days)    DAYS="${2:?--days requires a number}"; shift 2 ;;
+        --warn)    WARN_DAYS="${2:?--warn requires a number}"; shift 2 ;;
+        --root)    ROOT="${2:?--root requires a path}"; shift 2 ;;
+        --delete)  DO_DELETE=1; shift ;;
+        --yes)     ASSUME_YES=1; shift ;;
+        --verbose) VERBOSE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *)         log_error "Unknown argument: $1"; usage; exit 1 ;;
+    esac
+done
+
+if ! [[ "$DAYS" =~ ^[0-9]+$ ]] || ! [[ "$WARN_DAYS" =~ ^[0-9]+$ ]]; then
+    log_error "--days and --warn must be non-negative integers"
+    exit 1
+fi
+
+if [[ ! -d "$ROOT" ]]; then
+    log_error "scan root does not exist: $ROOT"
+    log_info "Claude Code may not have been used on this machine yet."
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+# File mtime in seconds since epoch (BSD vs GNU stat compatibility)
+file_mtime() {
+    if stat -f%m "$1" >/dev/null 2>&1; then
+        stat -f%m "$1"
+    else
+        stat -c%Y "$1"
+    fi
+}
+
+# Human-readable file size
+file_size_human() {
+    if command -v du >/dev/null 2>&1; then
+        du -h "$1" 2>/dev/null | awk '{print $1}'
+    else
+        echo "?"
+    fi
+}
+
+# Parse `name:` and `description:` from frontmatter (YAML between leading ---)
+parse_frontmatter() {
+    local file="$1"
+    local field="$2"
+    awk -v field="$field" '
+        BEGIN { in_fm=0; lines=0 }
+        /^---[[:space:]]*$/ {
+            if (in_fm) { exit } else { in_fm=1; next }
+        }
+        in_fm {
+            lines++
+            if (lines > 200) exit
+            # Match "field: value" with optional surrounding whitespace
+            if (match($0, "^[[:space:]]*" field "[[:space:]]*:[[:space:]]*")) {
+                val = substr($0, RSTART + RLENGTH)
+                # Strip surrounding quotes
+                gsub(/^["'"'"']|["'"'"']$/, "", val)
+                print val
+                exit
+            }
+        }
+    ' "$file"
+}
+
+age_days() {
+    local mtime="$1"
+    local now="$2"
+    echo $(( (now - mtime) / 86400 ))
+}
+
+color_for_age() {
+    local age="$1"
+    if   [[ "$age" -ge "$DAYS" ]];      then printf '%s' "$C_RED"
+    elif [[ "$age" -ge "$WARN_DAYS" ]]; then printf '%s' "$C_YELLOW"
+    else                                     printf '%s' "$C_GREEN"
+    fi
+}
+
+confirm() {
+    local prompt="$1"
+    [[ $ASSUME_YES -eq 1 ]] && return 0
+    read -r -p "$prompt [y/N] " reply
+    [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+# -----------------------------------------------------------------------------
+# Header
+# -----------------------------------------------------------------------------
+NOW="$(date +%s)"
+
+echo
+echo "================================================================"
+echo " ${C_BOLD}Claude Memory Audit${C_RESET}"
+echo "================================================================"
+log_info "scan root:    $ROOT"
+log_info "stale after:  $DAYS days  ${C_DIM}(warn at $WARN_DAYS)${C_RESET}"
+[[ $DO_DELETE -eq 1 ]] && log_warn "DELETE mode  ${C_DIM}(--yes=$ASSUME_YES)${C_RESET}"
+echo
+
+# -----------------------------------------------------------------------------
+# Scan
+# -----------------------------------------------------------------------------
+TOTAL_FILES=0
+TOTAL_STALE=0
+TOTAL_DELETED=0
+TOTAL_PROJECTS=0
+TOTAL_BYTES=0
+
+# Iterate ~/.claude/projects/*/memory/
+shopt -s nullglob
+for project_dir in "$ROOT"/*/; do
+    # Strip trailing slash from project_dir for cleaner output
+    project_dir="${project_dir%/}"
+    memory_dir="$project_dir/memory"
+    [[ -d "$memory_dir" ]] || continue
+
+    # Project name: encoded form is /-Users-foo-bar-MyApp — use the last
+    # hyphen-segment as a friendly name when possible.
+    encoded="$(basename "$project_dir")"
+    friendly="${encoded##*-}"
+    [[ -z "$friendly" ]] && friendly="$encoded"
+
+    project_files=0
+    project_stale=0
+    project_oldest=0
+    project_bytes=0
+
+    # Collect files into array (handle no-match)
+    files=()
+    while IFS= read -r -d '' f; do
+        files+=("$f")
+    done < <(find "$memory_dir" -type f -print0 2>/dev/null)
+
+    [[ ${#files[@]} -eq 0 ]] && continue
+
+    ((TOTAL_PROJECTS++)) || true
+    echo "${C_BOLD}# $friendly${C_RESET}  ${C_DIM}($memory_dir)${C_RESET}"
+
+    # Sort by mtime ascending (oldest first)
+    if [[ ${#files[@]} -gt 1 ]]; then
+        # shellcheck disable=SC2207
+        sorted=($(for f in "${files[@]}"; do
+            printf '%s\t%s\n' "$(file_mtime "$f")" "$f"
+        done | sort -n | cut -f2-))
+        files=("${sorted[@]}")
+    fi
+
+    for file in "${files[@]}"; do
+        mtime="$(file_mtime "$file")"
+        age="$(age_days "$mtime" "$NOW")"
+        size_bytes=0
+        if size_bytes_raw=$(wc -c <"$file" 2>/dev/null); then
+            size_bytes="${size_bytes_raw// /}"
+        fi
+        size_human="$(file_size_human "$file")"
+        rel="${file#$memory_dir/}"
+
+        ((project_files++)) || true
+        ((TOTAL_FILES++)) || true
+        project_bytes=$((project_bytes + size_bytes))
+        TOTAL_BYTES=$((TOTAL_BYTES + size_bytes))
+        [[ "$age" -gt "$project_oldest" ]] && project_oldest=$age
+
+        is_stale=0
+        [[ "$age" -ge "$DAYS" ]] && is_stale=1
+
+        if [[ "$is_stale" -eq 1 ]]; then
+            ((project_stale++)) || true
+            ((TOTAL_STALE++)) || true
+        fi
+
+        # Skip non-stale unless verbose
+        if [[ "$is_stale" -eq 0 ]] && [[ $VERBOSE -eq 0 ]]; then
+            continue
+        fi
+
+        color="$(color_for_age "$age")"
+        name_field="$(parse_frontmatter "$file" "name" 2>/dev/null || true)"
+        desc_field="$(parse_frontmatter "$file" "description" 2>/dev/null || true)"
+        meta=""
+        [[ -n "$name_field" ]] && meta=" ${C_DIM}name=${C_RESET}${name_field}"
+        if [[ -n "$desc_field" ]]; then
+            # Truncate long descriptions
+            short="${desc_field:0:70}"
+            [[ "${#desc_field}" -gt 70 ]] && short="${short}..."
+            meta="${meta} ${C_DIM}desc=${C_RESET}${short}"
+        fi
+
+        printf '  %s%4dd%s  %6s  %s%s\n' \
+            "$color" "$age" "$C_RESET" "$size_human" "$rel" "$meta"
+
+        if [[ "$is_stale" -eq 1 ]] && [[ $DO_DELETE -eq 1 ]]; then
+            if confirm "    delete $rel?"; then
+                rm -f "$file"
+                log_success "    deleted"
+                ((TOTAL_DELETED++)) || true
+            else
+                log_info "    skipped"
+            fi
+        fi
+    done
+
+    # Project summary
+    printf "  %s---%s files=%d stale=%d oldest=%dd size=%s\n\n" \
+        "$C_DIM" "$C_RESET" \
+        "$project_files" "$project_stale" "$project_oldest" \
+        "$(numfmt --to=iec --suffix=B "$project_bytes" 2>/dev/null || echo "${project_bytes}B")"
+done
+shopt -u nullglob
+
+# -----------------------------------------------------------------------------
+# Totals
+# -----------------------------------------------------------------------------
+echo "================================================================"
+echo " ${C_BOLD}Summary${C_RESET}"
+echo "================================================================"
+log_info "projects scanned: $TOTAL_PROJECTS"
+log_info "files total:      $TOTAL_FILES"
+if [[ "$TOTAL_STALE" -gt 0 ]]; then
+    log_warn "stale (>= ${DAYS}d): $TOTAL_STALE"
+else
+    log_success "stale (>= ${DAYS}d): 0"
+fi
+log_info "total size:       $(numfmt --to=iec --suffix=B "$TOTAL_BYTES" 2>/dev/null || echo "${TOTAL_BYTES}B")"
+[[ $DO_DELETE -eq 1 ]] && log_info "deleted:          $TOTAL_DELETED"
+
+if [[ $DO_DELETE -eq 0 ]] && [[ "$TOTAL_STALE" -gt 0 ]]; then
+    echo
+    log_info "re-run with --delete to prune (per-file confirmation)"
+    log_info "or --delete --yes for non-interactive cleanup"
+fi
+
+echo
+log_success "done"

--- a/scripts/arc-setup-notes-system.sh
+++ b/scripts/arc-setup-notes-system.sh
@@ -1,0 +1,318 @@
+#!/bin/bash
+# =============================================================================
+# arc-setup-notes-system.sh - Bootstrap the ARC notes/Obsidian system in a repo
+# =============================================================================
+#
+# Idempotent setup of the .claude/hooks/ scaffold used by every ARC project to
+# bridge the repository with its Obsidian vault folder. Run from inside the
+# target repo (or pass --root). Writes:
+#
+#   .claude/hooks/setup-notes.sh   (creates the `notes` symlink)
+#   .claude/hooks/sync-plans.sh    (Stop hook — archives Claude plans)
+#   .gitignore                     (appends `notes` if missing)
+#
+# Cross-machine safe: hooks resolve $HOME at runtime, never the current user.
+#
+# Usage:
+#   ./ARCDevTools/scripts/arc-setup-notes-system.sh
+#   ./ARCDevTools/scripts/arc-setup-notes-system.sh --name FavRes
+#   ./ARCDevTools/scripts/arc-setup-notes-system.sh --root /path/to/repo --dry-run
+#   ./ARCDevTools/scripts/arc-setup-notes-system.sh --verbose
+#
+# Project name detection:
+#   1. --name <ProjectName> if provided
+#   2. basename of git toplevel, with -iOS / -Android / -Web suffix stripped
+#
+# =============================================================================
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Color output (TTY-aware)
+# -----------------------------------------------------------------------------
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1 && [[ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]]; then
+    C_RED="$(tput setaf 1)"
+    C_GREEN="$(tput setaf 2)"
+    C_YELLOW="$(tput setaf 3)"
+    C_BLUE="$(tput setaf 4)"
+    C_DIM="$(tput dim)"
+    C_RESET="$(tput sgr0)"
+else
+    C_RED=""; C_GREEN=""; C_YELLOW=""; C_BLUE=""; C_DIM=""; C_RESET=""
+fi
+
+log_info()    { echo "${C_BLUE}i${C_RESET} $*"; }
+log_success() { echo "${C_GREEN}OK${C_RESET} $*"; }
+log_warn()    { echo "${C_YELLOW}!!${C_RESET} $*"; }
+log_error()   { echo "${C_RED}xx${C_RESET} $*" >&2; }
+log_debug()   { [[ "${VERBOSE:-0}" == "1" ]] && echo "${C_DIM}.. $*${C_RESET}" || true; }
+
+# -----------------------------------------------------------------------------
+# Defaults & argument parsing
+# -----------------------------------------------------------------------------
+PROJECT_NAME=""
+REPO_ROOT=""
+DRY_RUN=0
+VERBOSE=0
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Bootstrap the ARC notes/Obsidian system in the current repository.
+
+Options:
+  --name <ProjectName>   Override detected project name (default: git-derived)
+  --root <path>          Repository root (default: current git toplevel)
+  --dry-run              Show what would be done without writing anything
+  --verbose              Verbose logging
+  -h, --help             Show this help
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") --name FavRes
+  $(basename "$0") --root ~/Developer/Apps/FavRes-iOS --dry-run
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)     PROJECT_NAME="${2:?--name requires a value}"; shift 2 ;;
+        --root)     REPO_ROOT="${2:?--root requires a value}"; shift 2 ;;
+        --dry-run)  DRY_RUN=1; shift ;;
+        --verbose)  VERBOSE=1; shift ;;
+        -h|--help)  usage; exit 0 ;;
+        *)          log_error "Unknown argument: $1"; usage; exit 2 ;;
+    esac
+done
+
+# -----------------------------------------------------------------------------
+# Resolve repo root and project name
+# -----------------------------------------------------------------------------
+if [[ -z "$REPO_ROOT" ]]; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+if [[ ! -d "$REPO_ROOT" ]]; then
+    log_error "Repo root does not exist: $REPO_ROOT"
+    exit 1
+fi
+
+if [[ -z "$PROJECT_NAME" ]]; then
+    raw_name="$(basename "$REPO_ROOT")"
+    # Strip platform suffix: FavRes-iOS -> FavRes, MyApp-Android -> MyApp
+    PROJECT_NAME="${raw_name%-iOS}"
+    PROJECT_NAME="${PROJECT_NAME%-Android}"
+    PROJECT_NAME="${PROJECT_NAME%-Web}"
+    PROJECT_NAME="${PROJECT_NAME%-macOS}"
+fi
+
+VAULT_PATH="$HOME/Documents/ObsidianVault/01 - Projects/$PROJECT_NAME"
+HOOKS_DIR="$REPO_ROOT/.claude/hooks"
+GITIGNORE="$REPO_ROOT/.gitignore"
+
+echo
+echo "================================================================"
+echo " ARC Notes System Bootstrap"
+echo "================================================================"
+log_info "Repo root:    $REPO_ROOT"
+log_info "Project name: $PROJECT_NAME"
+log_info "Vault path:   $VAULT_PATH"
+[[ $DRY_RUN -eq 1 ]] && log_warn "DRY RUN — no files will be written"
+echo
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+# Render setup-notes.sh into a target path, parameterized by PROJECT_NAME.
+# Uses a quoted heredoc (no expansion) plus a sed substitution for the one
+# template variable — avoids quoting hell with $(...) and single quotes inside
+# the script body.
+render_setup_notes() {
+    local out="$1"
+    local name="$2"
+    cat > "$out" <<'TEMPLATE'
+#!/bin/bash
+# ARC Labs Studio - setup-notes.sh
+# Idempotent. Creates `notes/` symlink to Obsidian vault.
+# Cross-machine: uses $HOME, not hardcoded user.
+# Requires vault at $HOME/Documents/ObsidianVault/01 - Projects/__ARC_PROJECT_NAME__
+set -e
+PROJECT_NAME="__ARC_PROJECT_NAME__"
+VAULT_PATH="$HOME/Documents/ObsidianVault/01 - Projects/$PROJECT_NAME"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+if [ -L "notes" ]; then exit 0; fi
+if [ -e "notes" ] && [ ! -L "notes" ]; then
+  echo "[setup-notes] WARN: 'notes' exists and is not a symlink - skipping"
+  exit 0
+fi
+if [ ! -d "$VAULT_PATH" ]; then
+  echo "[setup-notes] vault not found at $VAULT_PATH - skipping (notes integration disabled on this machine)"
+  exit 0
+fi
+ln -s "$VAULT_PATH" notes
+echo "[setup-notes] linked notes -> $VAULT_PATH"
+TEMPLATE
+    # Substitute project name placeholder (use | as delimiter to allow / etc.)
+    # Use a portable in-place edit (BSD sed needs '' after -i)
+    if sed --version >/dev/null 2>&1; then
+        sed -i "s|__ARC_PROJECT_NAME__|${name}|g" "$out"
+    else
+        sed -i '' "s|__ARC_PROJECT_NAME__|${name}|g" "$out"
+    fi
+}
+
+render_sync_plans() {
+    local out="$1"
+    cat > "$out" <<'TEMPLATE'
+#!/bin/bash
+# ARC Labs Studio - sync-plans.sh (Stop hook)
+# Copies recently-modified Claude plans into notes/plans/ for archival.
+# Idempotent. Skips silently if notes/plans/ doesn't exist (un-symlinked checkout).
+set -e
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PLANS_DIR="$REPO_ROOT/notes/plans"
+SOURCE_DIR="$HOME/.claude/plans"
+[ -d "$PLANS_DIR" ] || exit 0
+[ -d "$SOURCE_DIR" ] || exit 0
+BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+# Strip type prefix: feature/FVRS-222-foo -> FVRS-222-foo
+BRANCH_SLUG="${BRANCH##*/}"
+DATE="$(date +%Y-%m-%d)"
+# Find plans modified in last 8 hours
+find "$SOURCE_DIR" -maxdepth 1 -type f -name "*.md" -mmin -480 2>/dev/null | while read -r plan; do
+  STEM="$(basename "$plan" .md)"
+  TARGET="$PLANS_DIR/${DATE}-${BRANCH_SLUG}-${STEM}.md"
+  [ -f "$TARGET" ] && continue   # idempotent
+  cp "$plan" "$TARGET" 2>/dev/null && echo "[sync-plans] copied $STEM -> notes/plans/"
+done
+exit 0
+TEMPLATE
+}
+
+# Render to a temp file and compare; only overwrite if different.
+maybe_install() {
+    local target="$1"
+    local renderer="$2"   # function name
+    local arg2="${3:-}"   # optional second arg passed to renderer
+    local label="${target#$REPO_ROOT/}"
+
+    local tmp
+    tmp="$(mktemp)"
+    if [[ -n "$arg2" ]]; then
+        "$renderer" "$tmp" "$arg2"
+    else
+        "$renderer" "$tmp"
+    fi
+
+    if [[ -f "$target" ]] && cmp -s "$tmp" "$target"; then
+        rm -f "$tmp"
+        log_info "up-to-date: $label"
+        return 0
+    fi
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        rm -f "$tmp"
+        log_info "would write: $label"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$target")"
+    mv "$tmp" "$target"
+    chmod 0755 "$target"
+    log_success "wrote: $label"
+}
+
+# -----------------------------------------------------------------------------
+# Step 1: Write hooks
+# -----------------------------------------------------------------------------
+log_info "Step 1/3 - Hooks"
+
+setup_path="$HOOKS_DIR/setup-notes.sh"
+sync_path="$HOOKS_DIR/sync-plans.sh"
+
+maybe_install "$setup_path" render_setup_notes "$PROJECT_NAME"
+maybe_install "$sync_path"  render_sync_plans
+
+# -----------------------------------------------------------------------------
+# Step 2: .gitignore
+# -----------------------------------------------------------------------------
+echo
+log_info "Step 2/3 — .gitignore"
+
+if [[ -f "$GITIGNORE" ]] && grep -qxE '^notes/?$' "$GITIGNORE"; then
+    log_info "already ignored: notes"
+else
+    if [[ $DRY_RUN -eq 1 ]]; then
+        log_info "would append 'notes' to .gitignore"
+    else
+        # Ensure trailing newline before appending
+        if [[ -f "$GITIGNORE" ]] && [[ -n "$(tail -c1 "$GITIGNORE" 2>/dev/null)" ]]; then
+            printf '\n' >> "$GITIGNORE"
+        fi
+        printf '\n# ARC notes system (Obsidian symlink)\nnotes\n' >> "$GITIGNORE"
+        log_success "appended 'notes' to .gitignore"
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Step 3: Try to run setup-notes.sh if vault exists
+# -----------------------------------------------------------------------------
+echo
+log_info "Step 3/3 — Vault detection"
+
+if [[ -d "$VAULT_PATH" ]]; then
+    log_success "vault found at: $VAULT_PATH"
+    if [[ $DRY_RUN -eq 1 ]]; then
+        log_info "would run setup-notes.sh to create the symlink"
+    else
+        if bash "$setup_path"; then
+            log_success "ran setup-notes.sh"
+        else
+            log_warn "setup-notes.sh exited non-zero — check above"
+        fi
+    fi
+else
+    log_warn "vault NOT found at: $VAULT_PATH"
+    log_info "create the folder in Obsidian, then re-run: bash .claude/hooks/setup-notes.sh"
+fi
+
+# -----------------------------------------------------------------------------
+# Next steps
+# -----------------------------------------------------------------------------
+echo
+echo "================================================================"
+echo " Next steps"
+echo "================================================================"
+cat <<NEXT
+
+1. Wire the hooks into .claude/settings.local.json:
+
+   {
+     "hooks": {
+       "SessionStart": [
+         { "hooks": [ { "type": "command",
+                        "command": ".claude/hooks/setup-notes.sh" } ] }
+       ],
+       "Stop": [
+         { "hooks": [ { "type": "command",
+                        "command": ".claude/hooks/sync-plans.sh" } ] }
+       ]
+     },
+     "permissions": {
+       "allow": [ "Write(./notes/**)" ]
+     }
+   }
+
+2. Add the "Notes & Obsidian" section to your CLAUDE.md (see the FavRes-iOS
+   CLAUDE.md for the canonical version — explains folder conventions,
+   troubleshooting note format, and plan auto-sync behavior).
+
+3. Each new clone or worktree must re-run setup-notes.sh (the symlink is
+   gitignored). The SessionStart hook handles this automatically.
+
+NEXT
+
+[[ $DRY_RUN -eq 1 ]] && log_warn "dry-run complete — nothing was written"
+log_success "done"


### PR DESCRIPTION
- arc-setup-notes-system.sh: idempotent bootstrap of .claude/hooks/ and .gitignore for the ARC notes/Obsidian convention. Detects project name from git, supports --name override and --dry-run.
- arc-memory-prune.sh: audit ~/.claude/projects/*/memory/ for stale entries (>60 days). Read-only by default; --delete with confirmation.

Implements plan section 5.5/5.6 Phase 3.