### PR TITLE
[FEATURE] Adopt [CATEGORY][TICKET-ID] PR title standard and de-emphasize xcodebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`scripts/key-obfuscator.swift`** — codegen for light obfuscation of client-public keys; emits a `[UInt8]` literal reconstructed at runtime via `ARCStorage.ConfigurationValue.deobfuscated(_:)`.
 - **ARCKnowledge: `Quality/api-keys.md`** — client secrets & API keys standard (real-secret vs client-public decision tree, xcconfig → Info.plist → `ConfigurationValue`, optional obfuscation, provider key restrictions). Wired into the `arc-quality-standards` skill.
 
+### Changed
+- **Pre-push hook** — no longer runs tests. Now runs SwiftLint (strict) and SwiftFormat (`--lint`) only; `xcodebuild test` / `swift test` were slow and environment-fragile (SPM resolution failures blocked pushes). Test gating stays in CI.
+- **PR title standard** — adopted `[CATEGORY][TICKET-ID] Description` (category mandatory: `FEATURE`/`BUGFIX`/`HOTFIX`/`DOCS`/`CHORE`; ticket optional). `validate-pr-title.yml`, the `arc-pr-publisher` / `arc-release-orchestrator` agents, and the `arc-workflow` skill docs were updated; bare conventional-commits titles are no longer accepted.
+- **Xcode tooling docs** — instructional snippets that told Claude/devs to run `xcodebuild` locally now point to the Xcode MCP (`arc-mcp-xcode` skill) as the preferred interactive path; CI workflows and Xcode Cloud scripts are unchanged.
+
 ---
 
 ## [2.13.1] - 2026-03-28

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ ARCDevTools standardizes development tooling across all ARC Labs projects. Add i
 
 The setup script detects your project type automatically.
 
+> The `make build` / `make test` targets shell out to `swift` / `xcodebuild`
+> for CI and headless use. For interactive build, test, and diagnostics, prefer
+> the Xcode MCP (see the `arc-mcp-xcode` skill).
+
 ---
 
 ## 📋 Requirements

--- a/arcdevtools-setup
+++ b/arcdevtools-setup
@@ -343,6 +343,10 @@ func generateMakefile(for projectType: ProjectType) throws {
         makefileContent = """
 # ARCDevTools Makefile (Swift Package)
 # Auto-generated - Do not edit manually
+#
+# build/test targets shell out to `swift` for CI and headless use.
+# For interactive build, test, and diagnostics, prefer the Xcode MCP
+# (see the `arc-mcp-xcode` skill) over running these targets by hand.
 
 .PHONY: help lint format fix build test setup hooks clean
 
@@ -406,6 +410,10 @@ clean:
         makefileContent = """
 # ARCDevTools Makefile (iOS App)
 # Auto-generated - Do not edit manually
+#
+# build/test targets shell out to `xcodebuild` for CI and headless use.
+# For interactive build, test, and diagnostics, prefer the Xcode MCP
+# (see the `arc-mcp-xcode` skill) over running these targets by hand.
 
 \(schemeNote)
 DESTINATION ?= platform=iOS Simulator,name=iPhone 16,OS=latest

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,47 +1,72 @@
 #!/bin/bash
 
 # ARCDevTools Pre-push Hook
-# Runs tests before pushing to remote
-# Supports both SPM packages (Package.swift) and Xcode projects (.xcodeproj)
+# Runs fast, environment-stable quality checks before pushing to remote.
+#
+# Scope: SwiftLint + SwiftFormat validation only. Tests are NOT run here —
+# `xcodebuild test` / `swift test` are slow and environment-fragile (SPM
+# resolution failures would block pushes). Test gating belongs in CI.
+#
+# Bypass: `SKIP_HOOKS=1 git push` (NOT recommended — CI runs the same checks).
 
-echo "🚀 Pre-push: Running tests..."
-
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-
-if [ -f "$REPO_ROOT/Makefile" ]; then
-    # Prefer Makefile — it already has the correct test command for the project type
-    make -C "$REPO_ROOT" test
-elif [ -f "$REPO_ROOT/Package.swift" ]; then
-    # SPM package
-    swift test --parallel --package-path "$REPO_ROOT"
-else
-    # Look for .xcodeproj in repo root or one level deep
-    XCODEPROJ=$(find "$REPO_ROOT" -maxdepth 2 -name "*.xcodeproj" -not -path "*/DerivedData/*" | head -1)
-    if [ -n "$XCODEPROJ" ]; then
-        SCHEME=$(basename "$XCODEPROJ" .xcodeproj)
-        xcodebuild test \
-            -project "$XCODEPROJ" \
-            -scheme "$SCHEME" \
-            -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest" \
-            -configuration Debug \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            -quiet
-    else
-        echo "⚠️  No Package.swift, Makefile, or .xcodeproj found. Skipping tests."
-        exit 0
-    fi
+if [ "$SKIP_HOOKS" = "1" ]; then
+    echo ""
+    echo "⚠️  Pre-push checks skipped (SKIP_HOOKS=1)."
+    echo "    CI will run the same checks and reject the PR if there are violations."
+    echo ""
+    exit 0
 fi
 
-TEST_EXIT_CODE=$?
+echo "🚀 Pre-push: Running quality checks..."
 
-if [ $TEST_EXIT_CODE -ne 0 ]; then
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT" || exit 1
+
+FAILED=0
+
+# 1. SwiftFormat (lint mode — no auto-fix)
+if command -v swiftformat >/dev/null 2>&1; then
     echo ""
-    echo "❌ Tests failed. Push aborted."
-    echo "💡 Fix failing tests or use --no-verify to bypass (not recommended)"
+    echo "  Checking formatting (SwiftFormat)..."
+    if [ -f ".swiftformat" ]; then
+        if swiftformat --lint --config .swiftformat . >/dev/null 2>&1; then
+            echo "  ✅ SwiftFormat passed"
+        else
+            echo "  ❌ SwiftFormat found unformatted files"
+            FAILED=1
+        fi
+    else
+        echo "  No .swiftformat config found, skipping..."
+    fi
+else
+    echo "  SwiftFormat not installed (brew install swiftformat), skipping..."
+fi
+
+# 2. SwiftLint (strict mode)
+if command -v swiftlint >/dev/null 2>&1; then
+    echo ""
+    echo "  Running SwiftLint..."
+    if [ -f ".swiftlint.yml" ]; then
+        if swiftlint lint --config .swiftlint.yml --strict --quiet; then
+            echo "  ✅ SwiftLint passed"
+        else
+            FAILED=1
+        fi
+    else
+        echo "  No .swiftlint.yml config found, skipping..."
+    fi
+else
+    echo "  SwiftLint not installed (brew install swiftlint), skipping..."
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+    echo ""
+    echo "❌ Quality checks failed. Push aborted."
+    echo "💡 Fix the violations above, or run 'make fix' to auto-format."
+    echo "   Use 'SKIP_HOOKS=1 git push' to bypass (NOT recommended)."
     exit 1
 fi
 
-echo "✅ All tests passed. Proceeding with push."
+echo ""
+echo "✅ Quality checks passed. Proceeding with push."
 exit 0

--- a/workflows-spm/validate-pr-title.yml
+++ b/workflows-spm/validate-pr-title.yml
@@ -17,36 +17,29 @@ jobs:
           echo "PR Title: $PR_TITLE"
           echo ""
 
-          # Format 1: Linear ticket — [TEAM-123] Description
-          LINEAR_PATTERN='^(\[[A-Z]+-[0-9]+\]) .{5,}'
+          # Required format: [CATEGORY][TICKET-ID] Description
+          #   - [CATEGORY] is mandatory: FEATURE, BUGFIX, HOTFIX, DOCS, CHORE
+          #   - [TICKET-ID] is optional: omit when there is no ticket
+          TITLE_PATTERN='^\[(FEATURE|BUGFIX|HOTFIX|DOCS|CHORE)\](\[[A-Z]+-[0-9]+\])? .{5,}'
 
-          # Format 2: Conventional Commits — type(scope): description
-          CONVENTIONAL_PATTERN='^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\(.+\))?!?: .{5,}'
-
-          if [[ "$PR_TITLE" =~ $LINEAR_PATTERN ]]; then
-            echo "✅ Valid format (Linear): $PR_TITLE"
-            exit 0
-          fi
-
-          if [[ "$PR_TITLE" =~ $CONVENTIONAL_PATTERN ]]; then
-            echo "✅ Valid format (Conventional Commits): $PR_TITLE"
+          if [[ "$PR_TITLE" =~ $TITLE_PATTERN ]]; then
+            echo "✅ Valid format: $PR_TITLE"
             exit 0
           fi
 
           echo "❌ PR title does not match required format."
           echo ""
-          echo "Use one of the following formats:"
+          echo "Required format:"
           echo ""
-          echo "  With Linear ticket:"
-          echo "    [TEAM-123] Short description of the change"
+          echo "    [CATEGORY][TICKET-ID] Short description of the change"
           echo ""
-          echo "  Without Linear ticket (Conventional Commits):"
-          echo "    type(scope): short description"
+          echo "  - [CATEGORY] is mandatory."
+          echo "  - [TICKET-ID] is optional — omit it when there is no ticket."
           echo ""
-          echo "  Valid types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert"
+          echo "  Valid categories: FEATURE, BUGFIX, HOTFIX, DOCS, CHORE"
           echo ""
           echo "  Examples:"
-          echo "    [FVRS-189] Revert glass-on-glass overlays and add page indicator fallback"
-          echo "    fix(ui): revert glass-on-glass overlays and add page indicator fallback"
-          echo "    feat(auth): add biometric login support"
+          echo "    [FEATURE][FVRS-11] Add new feature"
+          echo "    [BUGFIX][FVRS-12] Fix new feature tests"
+          echo "    [CHORE] Bump dependencies"
           exit 1


### PR DESCRIPTION
## Summary

Two tooling changes, plus the matching ARCKnowledge submodule bump.

### 1. PR title standard — `[CATEGORY][TICKET-ID] Description`

`validate-pr-title.yml` now enforces a single canonical pattern:
`[CATEGORY][TICKET-ID] Description`. `[CATEGORY]` is mandatory
(`FEATURE`, `BUGFIX`, `HOTFIX`, `DOCS`, `CHORE`); `[TICKET-ID]` is optional
(omitted when there is no ticket). Bare conventional-commits titles are no
longer accepted.

### 2. xcodebuild de-emphasis

- **`hooks/pre-push`** — no longer runs tests. `xcodebuild test` / `swift test`
  were slow and environment-fragile (SPM resolution failures blocked pushes).
  The hook now runs SwiftLint (strict) + SwiftFormat (`--lint`) only; test
  gating stays in CI.
- **`arcdevtools-setup`** — generated Makefiles carry a header note pointing to
  the Xcode MCP (`arc-mcp-xcode` skill) as the preferred interactive path.
  Build/test targets still shell out to `swift`/`xcodebuild` for CI use.
- **`README.md`** — flags the Xcode MCP as the preferred interactive path.

CI workflows and Xcode Cloud `ci_scripts/` are unchanged — `xcodebuild` is
genuinely required there.

### 3. Submodule

`ARCKnowledge` bumped to `main` `5320111`, which carries the matching
agent/skill/doc updates (ARCKnowledge #97 → #99).

## Verification

- PR title regex: `[FEATURE][FVRS-11] …` / `[CHORE] …` pass; bare
  conventional-commits and category-less titles reject.
- `bash -n hooks/pre-push` clean.
- `arcdevtools-setup` typechecks (`swiftc -typecheck`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)