### PR TITLE
[BUGFIX] Exclude the ARCDevTools submodule from formatting and linting

### DIFF
--- a/configs/swiftformat
+++ b/configs/swiftformat
@@ -1,5 +1,5 @@
 # ARCDevTools SwiftFormat Configuration
-# Version: 1.0.0
+# Version: 1.1.0
 
 # Indentation
 --indent 4
@@ -52,4 +52,8 @@
 --extensionacl on-extension
 
 # Exclude
---exclude .build,DerivedData,Pods,Carthage,Generated
+# ARCDevTools / Tools/ARCDevTools are the submodule itself — `make fix` runs
+# swiftformat over `.`, so without these it reformats the tooling repo's own
+# sources and leaves the submodule dirty. .arc-tools holds downloaded binaries.
+# Mirrors the `excluded:` list in swiftlint.base.yml.
+--exclude .build,DerivedData,Pods,Carthage,Generated,ARCDevTools,Tools/ARCDevTools,.arc-tools

--- a/configs/swiftlint.base.yml
+++ b/configs/swiftlint.base.yml
@@ -1,5 +1,5 @@
 # ARCDevTools SwiftLint Base Configuration
-# Version: 1.2.0
+# Version: 1.3.0
 #
 # This file ships the studio-wide rule set. It is copied verbatim into every
 # consumer project as `.swiftlint.base.yml` on every `arcdevtools-setup` run,
@@ -20,7 +20,9 @@ excluded:
   - DerivedData
   - Pods
   - Carthage
-  - ARCDevTools
+  - ARCDevTools        # submodule, usual location
+  - Tools/ARCDevTools  # submodule, nested location (e.g. FavRes-iOS)
+  - .arc-tools         # downloaded pinned linter binaries
   - "*/Generated/*"
   - "*.generated.swift"
 


### PR DESCRIPTION
## Problem

Caught during the v2.14.1 rollout into ARCPurchasing: after `make fix`, the ARCDevTools submodule was left dirty.

`make fix` runs `swiftformat --config .swiftformat .`, and `configs/swiftformat` only excluded build directories. So it walked into the submodule and reformatted the tooling repo's own sources (`scripts/key-obfuscator.swift`), producing a `-dirty` submodule pointer in the consumer project.

`configs/swiftlint.base.yml` excluded `ARCDevTools` but not the nested `Tools/ARCDevTools` layout FavRes-iOS uses, nor `.arc-tools`.

## Fix

Both configs now exclude `ARCDevTools`, `Tools/ARCDevTools` and `.arc-tools`, keeping the two lists in sync.

## Rollout caveat

`.swiftformat` is project-owned and not overwritten on setup re-runs, so existing projects need the `--exclude` line updated by hand. Doing that as part of the in-flight rollout PRs.

## Verification

Scratch project re-set-up with `--force`: `make fix` no longer touches any Swift file inside the submodule; the submodule stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)