### PR TITLE
[BUGFIX] Gitignore symlinks created by earlier setup runs

### DIFF
--- a/arcdevtools-setup
+++ b/arcdevtools-setup
@@ -723,8 +723,14 @@ func setupClaudeSkills() throws -> [String] {
                 continue
             }
 
-            // Skip if already exists (don't overwrite ARCDevTools skills)
+            // Skip if already exists (don't overwrite ARCDevTools skills).
+            // A pre-existing *symlink* is one we created on an earlier run, so
+            // it still belongs in .gitignore — otherwise projects set up before
+            // a given skill was gitignored never get the entry.
             if fileManager.fileExists(atPath: destSkill.path) {
+                if (try? destSkill.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink == true {
+                    symlinkedSkills.append(skillName)
+                }
                 continue
             }
 
@@ -855,9 +861,16 @@ func setupClaudeAgents() throws -> [String] {
     for filename in agentFiles where filename.hasSuffix(".md") && filename.hasPrefix("arc-") {
         let destFile = agentsDir.appendingPathComponent(filename)
 
-        // Skip if already exists (project-local agent takes priority)
+        // Skip if already exists (project-local agent takes priority).
+        // A pre-existing symlink came from an earlier run of this script, so it
+        // still needs its .gitignore entry — see the equivalent case in
+        // setupClaudeSkills().
         if fileManager.fileExists(atPath: destFile.path) {
-            printWarning("   \(filename) already exists — skipping")
+            if (try? destFile.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink == true {
+                symlinkedAgents.append(filename)
+            } else {
+                printWarning("   \(filename) already exists — skipping")
+            }
             continue
         }
 


### PR DESCRIPTION
## Problem

#156 fixed the `.gitignore` updaters to append missing entries, but did not fix *what they are called with*. Both are invoked only with the symlinks created during the current run:

```swift
if !symlinkedSkills.isEmpty {
    try updateGitignoreWithSkills(symlinkedSkills)
}
```

Skills and agents linked by an earlier run hit the `already exists` guard and never reach that list. So a project whose `.gitignore` predates a given entry never gets it, no matter how many times setup runs.

Reproduced in ARCPurchasing: four skills stayed untracked across two consecutive setup runs on v2.14.1.

## Fix

Pre-existing entries are included when the destination is a symlink — meaning this script created it. A real file or directory is still skipped: those are the copied ARCDevTools skills (`arc-package-validator`, `git-branch-sync`), which belong in git.

## Verification

Scratch project, set up once to create the symlinks, `.gitignore` then reset to simulate an older project, set up again:

- 15 skill entries and 12 agent entries restored despite every symlink already existing
- the only untracked paths left are the copied ARCDevTools skills, as intended
- `swiftc -typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)