### PR TITLE
[BUGFIX] Pre-commit hook aborts on staged files under ignored paths

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ARCDevTools Pre-commit Hook
-# Version: 1.2.0
+# Version: 1.3.0
 
 set -e
 
@@ -54,8 +54,12 @@ if [ -n "$SWIFTFORMAT_BIN" ]; then
   arc_tool_warn swiftformat
   echo "$STAGED_SWIFT" | xargs "$SWIFTFORMAT_BIN" --config .swiftformat 2>&1 | grep -v "running" || true
 
-  # Re-stage archivos formateados
-  echo "$STAGED_SWIFT" | xargs git add
+  # Re-stage archivos formateados.
+  # -f porque algunos repos ignoran rutas que sí tienen ficheros trackeados
+  # (p. ej. .claude/skills/ con arc-package-validator dentro). Sin -f, `git add`
+  # aborta con "paths are ignored", y con `set -e` eso bloquea el commit entero.
+  # Es seguro: estos ficheros ya estaban en stage, luego ya están trackeados.
+  echo "$STAGED_SWIFT" | xargs git add -f
   echo "  Formato aplicado"
 else
   arc_tool_warn swiftformat


### PR DESCRIPTION
## Problem

Reproduced in ARCDistribution during the v2.14.3 rollout: every commit was blocked.

The hook re-stages files after running SwiftFormat:

```bash
echo "$STAGED_SWIFT" | xargs git add
```

Several repos gitignore `.claude/skills/` while still tracking the ARCDevTools skills copied inside it (`arc-package-validator`). Plain `git add` refuses those paths:

```
The following paths are ignored by one of your .gitignore files:
.claude/skills
hint: Use -f if you really want to add them.
```

With `set -e` at the top of the hook, that non-zero exit aborted the hook and the commit with it. Any change touching a tracked file under an ignored directory was uncommittable.

## Fix

`git add -f`. Safe by construction: these files were already staged when the hook ran, so they are already tracked — `-f` only bypasses the ignore check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)