### PR TITLE
[BUGFIX] Use absolute ARCKnowledge URLs in arc-package-validator docs

### DIFF
--- a/.claude/skills/arc-package-validator/SKILL.md
+++ b/.claude/skills/arc-package-validator/SKILL.md
@@ -98,6 +98,6 @@ The validator generates a Markdown report with:
 For detailed standards and checklist, see [references/checklist.md](references/checklist.md).
 
 For ARCKnowledge documentation:
-- [package-structure.md](../../ARCKnowledge/Quality/package-structure.md)
-- [readme-standards.md](../../ARCKnowledge/Quality/readme-standards.md)
-- [arcdevtools.md](../../ARCKnowledge/Tools/arcdevtools.md)
+- [package-structure.md](https://github.com/arclabs-studio/ARCKnowledge/blob/main/Quality/package-structure.md)
+- [readme-standards.md](https://github.com/arclabs-studio/ARCKnowledge/blob/main/Quality/readme-standards.md)
+- [arcdevtools.md](https://github.com/arclabs-studio/ARCKnowledge/blob/main/Tools/arcdevtools.md)


### PR DESCRIPTION
## Problem

The `Validate Markdown Links` job failed in every consumer repo that picked up the skill during the v2.14.x rollout:

```
[✖] ../../ARCKnowledge/Quality/package-structure.md → Status: 400
[✖] ../../ARCKnowledge/Quality/readme-standards.md → Status: 400
[✖] ../../ARCKnowledge/Tools/arcdevtools.md → Status: 400
ERROR: 3 dead links found!
```

`SKILL.md` sits at `.claude/skills/arc-package-validator/`, so `../../` resolves to `.claude/` — the links were broken in this repo too, not just downstream.

No relative depth fixes both layouts: in ARCDevTools ARCKnowledge is a sibling submodule, while in consumer projects the skill is copied to `.claude/skills/` and ARCKnowledge lives under a submodule path that varies per project (`ARCDevTools/` vs FavRes-iOS's `Tools/ARCDevTools/`).

## Fix

Point at the ARCKnowledge repo on GitHub. Checked the other copied skills for the same pattern — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)