### PR TITLE
[FIX] Setup: stop copying ARCDevTools' own CI and piling onto existing workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.15.0] - 2026-08-10
+
+### Fixed
+
+- **Setup copied ARCDevTools' own CI into consumer projects.** `docs.yml` and `validate-release.yml` sit in `workflows-spm/`, so setup treated them as templates — but `docs.yml` hardcodes `xcodebuild -scheme ARCDevTools` and `validate-release.yml` builds `--product arcdevtools-setup`. Every project that received them got a workflow that can only fail. They trigger on pushes to `main` and on tags rather than on pull requests, which is why the breakage never surfaced in PR checks. Setup no longer copies either; they remain in place as ARCDevTools' own workflows.
+- **Setup piled the whole template set onto projects that maintain their own CI.** Re-running it in a repo with a hand-written `ci.yml` added eight template workflows beside it: duplicate lint and build jobs, plus gates the project never opted into (`release-drafter.yml` fails by construction on a feature branch, since its config must live on the default branch). Such projects now get only their existing ARCDevTools-generated workflows refreshed.
+
+  Ownership is decided by the `# ARCDevTools Workflow Template` header rather than the filename, so a `quality.yml` a project has taken over counts as project-owned and is never overwritten. `--all-workflows` installs the full set regardless.
+
+### Added
+
+- **`--all-workflows` flag** — installs the complete template workflow set even in a project that owns its CI. Off by default.
+
+### Changed
+
+- **ARCKnowledge submodule → v2.16.0.** Brings the dead-link cleanup (30 → 0, verified with the same `markdown-link-check` config ARC CI uses) and the `arc-testflight` agent alignment with the tag-push Xcode Cloud pipeline. Also the first ARCKnowledge tag containing the `AGENTS.md` Xcode Tooling Policy section and the `Quality/api-keys.md` standard, which had shipped to `main` untagged.
+- **`arcdevtools-setup` → 1.4.0.**
+
+---
+
 ## [2.14.5] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -316,8 +316,19 @@ Workflows are templates adapted per project type. Choose to install them during 
 - `enforce-gitflow.yml` — Branch rule enforcement
 - `sync-develop.yml` — Auto-sync main to develop
 - `release-drafter.yml` — Auto-draft release notes from PRs
+- `validate-pr-title.yml` — Conventional Commits check on PR titles
 
-**SPM-only:** `docs.yml` (DocC), `validate-release.yml`
+**Not templates:** `docs.yml` and `validate-release.yml` also live in `workflows-spm/`, but they are ARCDevTools' own CI — `docs.yml` hardcodes `xcodebuild -scheme ARCDevTools` and `validate-release.yml` builds `--product arcdevtools-setup`. Setup never copies them; in a consumer project they could only fail.
+
+**Projects with their own CI**
+
+If `.github/workflows/` already contains a workflow ARCDevTools did not generate — a hand-written `ci.yml`, or a `quality.yml` the project has taken over — setup refreshes only the workflows it generated and adds nothing new. Piling the template set next to hand-written CI produces duplicate lint and build jobs plus gates the project never opted into.
+
+Ownership is judged by the `# ARCDevTools Workflow Template` header, not the filename, so a file you take over is never overwritten. To install the full set regardless:
+
+```bash
+./ARCDevTools/arcdevtools-setup --with-workflows --all-workflows
+```
 
 > **Billing note:** macOS runners have a 10x billing multiplier on GitHub Actions. ARCDevTools optimizes by running lint/format on Ubuntu. See [docs/ci-cd.md](docs/ci-cd.md) for details.
 

--- a/arcdevtools-setup
+++ b/arcdevtools-setup
@@ -11,7 +11,7 @@ import Foundation
 
 // MARK: - Constants
 
-let version = "1.3.0"
+let version = "1.4.0"
 
 // MARK: - Project Type Detection
 
@@ -34,6 +34,7 @@ struct Options {
     var noWorkflows: Bool = false
     var showHelp: Bool = false
     var force: Bool = false
+    var allWorkflows: Bool = false
 
     var isInteractive: Bool {
         !withWorkflows && !noWorkflows
@@ -52,6 +53,8 @@ func parseArguments() -> Options {
             options.noWorkflows = true
         case "--force", "-f":
             options.force = true
+        case "--all-workflows":
+            options.allWorkflows = true
         case "--help", "-h":
             options.showHelp = true
         default:
@@ -73,6 +76,9 @@ func printHelp() {
     print("  --no-workflows    Skip GitHub Actions workflows (non-interactive)")
     print("  --force, -f       Overwrite project-owned configs (.swiftlint.yml, .swiftformat)")
     print("                    Studio-owned configs (.swiftlint.base.yml) always refresh.")
+    print("  --all-workflows   Add the full template workflow set even to a repo that")
+    print("                    maintains its own CI. Off by default: such repos only get")
+    print("                    their existing ARCDevTools-generated workflows refreshed.")
     print("  --help, -h        Show this help message")
     print("")
     print("Examples:")
@@ -557,7 +563,48 @@ func rewriteToolsPath(in content: String) -> String {
     return content.replacingOccurrences(of: "ARCDevTools/", with: "\(arcDevToolsPath)/")
 }
 
-func setupWorkflows(for projectType: ProjectType) throws {
+/// Header stamped onto every workflow this script generates. Its presence is how
+/// a later run tells "we wrote this" apart from "the project wrote this".
+let workflowTemplateMarker = "# ARCDevTools Workflow Template"
+
+/// `docs.yml` and `validate-release.yml` live in `workflows-spm/` for historical
+/// reasons, but they are ARCDevTools' own CI rather than templates: `docs.yml`
+/// hardcodes `xcodebuild -scheme ARCDevTools` and `validate-release.yml` builds
+/// `--product arcdevtools-setup`. Copied into a consumer they produce workflows
+/// that can only fail. Excluded here rather than moved, so ARCDevTools' own CI
+/// setup is left untouched.
+let arcDevToolsOwnWorkflows: Set<String> = ["docs.yml", "validate-release.yml"]
+
+/// True when the project maintains hand-written CI — that is, any workflow this
+/// script did not generate. Judged by the template header rather than the
+/// filename, so a `quality.yml` the project has taken over counts the same as a
+/// bespoke `ci.yml`.
+///
+/// Dropping the full template set next to hand-written CI produces duplicate
+/// coverage (two lint jobs, two build jobs) and gates the repo never opted into,
+/// so those repos get their existing ARCDevTools-generated workflows refreshed
+/// and nothing new added unless `--all-workflows` is passed.
+func projectOwnsItsCI(workflowsDir: URL) -> Bool {
+    guard let files = try? fileManager.contentsOfDirectory(atPath: workflowsDir.path) else {
+        return false
+    }
+
+    for filename in files where filename.hasSuffix(".yml") || filename.hasSuffix(".yaml") {
+        // Claude Code installs its own workflows; they are not a signal about
+        // how the project manages CI and never collide with the template set.
+        if filename.hasPrefix("claude") { continue }
+
+        let path = workflowsDir.appendingPathComponent(filename)
+        let content = (try? String(contentsOf: path, encoding: .utf8)) ?? ""
+        if !content.hasPrefix(workflowTemplateMarker) {
+            return true
+        }
+    }
+
+    return false
+}
+
+func setupWorkflows(for projectType: ProjectType, allWorkflows: Bool) throws {
     print("")
     printInfo("⚙️  Copying GitHub Actions workflows (\(projectType.displayName))...")
 
@@ -582,22 +629,45 @@ func setupWorkflows(for projectType: ProjectType) throws {
     try? fileManager.createDirectory(at: githubWorkflowsDir, withIntermediateDirectories: true)
 
     // Workflows specific to project type (quality.yml, tests.yml)
-    let projectSpecificWorkflows = ["quality.yml", "tests.yml"]
+    let projectSpecificWorkflows: Set<String> = ["quality.yml", "tests.yml"]
 
-    // Copy project-specific workflows from the appropriate directory
-    let workflowFiles = try fileManager.contentsOfDirectory(atPath: workflowsSource.path)
-    for filename in workflowFiles where filename.hasSuffix(".yml") {
-        let sourceFile = workflowsSource.appendingPathComponent(filename)
+    let ownsCI = projectOwnsItsCI(workflowsDir: githubWorkflowsDir)
+    let addNewWorkflows = allWorkflows || !ownsCI
+    var skipped: [String] = []
+
+    if ownsCI, !allWorkflows {
+        printInfo("   This project has its own CI workflows.")
+        printInfo("   Refreshing only the workflows ARCDevTools generated; not adding new ones.")
+        printInfo("   Pass --all-workflows to install the full template set anyway.")
+    }
+
+    /// Writes one template, unless it would be a new file in a project that owns
+    /// its CI. Returns whether it wrote.
+    func installWorkflow(named filename: String, from sourceDir: URL, sourceLabel: String, header: String) throws -> Bool {
         let destFile = githubWorkflowsDir.appendingPathComponent(filename)
+        let exists = fileManager.fileExists(atPath: destFile.path)
 
-        let originalContent = try String(contentsOf: sourceFile, encoding: .utf8)
+        if !exists, !addNewWorkflows {
+            skipped.append(filename)
+            return false
+        }
 
+        // A file we did not generate belongs to the project — never clobber it.
+        if exists {
+            let current = (try? String(contentsOf: destFile, encoding: .utf8)) ?? ""
+            if !current.hasPrefix(workflowTemplateMarker) {
+                skipped.append("\(filename) (project-owned, kept)")
+                return false
+            }
+        }
+
+        let originalContent = try String(contentsOf: sourceDir.appendingPathComponent(filename), encoding: .utf8)
         let templateComment = """
-        # ARCDevTools Workflow Template (\(projectType.displayName))
-        # Source: https://github.com/arclabs-studio/ARCDevTools/\(workflowsDirName)/\(filename)
+        \(header)
+        # Source: https://github.com/arclabs-studio/ARCDevTools/\(sourceLabel)/\(filename)
         #
         # This file was copied from ARCDevTools. You can customize it for your project.
-        # To update: re-run ./\(arcDevToolsPath)/arcdevtools-setup or manually copy from \(arcDevToolsPath)/\(workflowsDirName)/
+        # To update: re-run ./\(arcDevToolsPath)/arcdevtools-setup or manually copy from \(arcDevToolsPath)/\(sourceLabel)/
 
         """
         let newContent = templateComment + rewriteToolsPath(in: originalContent)
@@ -605,36 +675,44 @@ func setupWorkflows(for projectType: ProjectType) throws {
         try? fileManager.removeItem(at: destFile)
         try newContent.write(to: destFile, atomically: true, encoding: .utf8)
         printSuccess("   \(filename)")
+        return true
     }
 
-    // Copy shared workflows from workflows-spm/ directory (those not project-specific)
+    // Copy project-specific workflows from the appropriate directory
+    // `workflows-spm/` doubles as the shared directory, so ARCDevTools' own CI
+    // files sit alongside the templates and must be filtered here too.
+    let workflowFiles = try fileManager.contentsOfDirectory(atPath: workflowsSource.path)
+    for filename in workflowFiles.sorted()
+    where filename.hasSuffix(".yml") && !arcDevToolsOwnWorkflows.contains(filename) {
+        _ = try installWorkflow(
+            named: filename,
+            from: workflowsSource,
+            sourceLabel: workflowsDirName,
+            header: "\(workflowTemplateMarker) (\(projectType.displayName))"
+        )
+    }
+
+    // Copy shared workflows from workflows-spm/ — those that are neither
+    // project-type-specific nor ARCDevTools' own CI.
     if fileManager.fileExists(atPath: sharedWorkflowsSource.path) {
         let sharedFiles = try fileManager.contentsOfDirectory(atPath: sharedWorkflowsSource.path)
-        for filename in sharedFiles where filename.hasSuffix(".yml") && !projectSpecificWorkflows.contains(filename) {
-            let sourceFile = sharedWorkflowsSource.appendingPathComponent(filename)
-            let destFile = githubWorkflowsDir.appendingPathComponent(filename)
-
-            // Skip if already exists (don't overwrite project-specific)
-            if fileManager.fileExists(atPath: destFile.path) {
-                continue
-            }
-
-            let originalContent = try String(contentsOf: sourceFile, encoding: .utf8)
-
-            let templateComment = """
-            # ARCDevTools Workflow Template
-            # Source: https://github.com/arclabs-studio/ARCDevTools/workflows-spm/\(filename)
-            #
-            # This file was copied from ARCDevTools. You can customize it for your project.
-            # To update: re-run ./\(arcDevToolsPath)/arcdevtools-setup or manually copy from \(arcDevToolsPath)/workflows-spm/
-
-            """
-            let newContent = templateComment + rewriteToolsPath(in: originalContent)
-
-            try? fileManager.removeItem(at: destFile)
-            try newContent.write(to: destFile, atomically: true, encoding: .utf8)
-            printSuccess("   \(filename)")
+        let shared = sharedFiles.sorted().filter {
+            $0.hasSuffix(".yml")
+                && !projectSpecificWorkflows.contains($0)
+                && !arcDevToolsOwnWorkflows.contains($0)
         }
+        for filename in shared {
+            _ = try installWorkflow(
+                named: filename,
+                from: sharedWorkflowsSource,
+                sourceLabel: "workflows-spm",
+                header: workflowTemplateMarker
+            )
+        }
+    }
+
+    if !skipped.isEmpty {
+        printInfo("   Not installed: \(skipped.joined(separator: ", "))")
     }
 
     // Copy templates
@@ -1046,7 +1124,7 @@ func main() {
         }
 
         if shouldInstallWorkflows {
-            try setupWorkflows(for: projectType)
+            try setupWorkflows(for: projectType, allWorkflows: options.allWorkflows)
         }
 
         // Handle ci_scripts installation (iOS Apps only)


### PR DESCRIPTION
## Summary

Two independent bugs in `setupWorkflows`, plus the ARCKnowledge bump to v2.16.0.

## 🐛 Bug 1 — setup copied ARCDevTools' own CI into consumer projects

`docs.yml` and `validate-release.yml` live in `workflows-spm/`, so setup treated them as templates. They are not templates:

- `docs.yml` runs `xcodebuild docbuild -scheme ARCDevTools`
- `validate-release.yml` runs `swift build -c release --product arcdevtools-setup` and prints "Building ARCDevTools in release mode"

Any project that received them got a workflow that can only fail. Both trigger on pushes to `main` and on tags rather than on pull requests — which is exactly why this never surfaced in PR checks.

**Already affected, on their own `develop`:** ARCPurchasing, ARCLogger, ARCMetrics, ARCIntelligence, ARCAuthentication all carry `docs.yml` with `-scheme ARCDevTools`. This PR stops the bleeding; cleaning up those five is separate.

The project-type copy loop needed the same filter as the shared loop, since `workflows-spm/` doubles as the shared directory — filtering only the shared loop left SPM consumers still receiving both files.

## 🐛 Bug 2 — setup piled the template set onto projects with their own CI

Re-running setup in a repo that keeps a hand-written `ci.yml` added eight template workflows beside it: two lint jobs, two build jobs, and gates the repo never opted into. `release-drafter.yml` is the worst of these — it fails by construction on a feature branch, because its config must live on the default branch.

Now: a project with hand-written CI gets only its existing ARCDevTools-generated workflows refreshed, and nothing new added.

Ownership is decided by the `# ARCDevTools Workflow Template` header, **not** the filename. A `quality.yml` the project has taken over counts as project-owned and is never overwritten. `--all-workflows` installs the full set regardless.

## Verification

Six throwaway fixtures, each asserting the resulting `.github/workflows/` contents:

| Case | Setup | Expected | Result |
|---|---|---|---|
| A | Swift package, no CI | template set, no `docs.yml` / `validate-release.yml` | ✅ |
| B | package + hand-written `ci.yml` | only `ci.yml` | ✅ |
| C | same as B, `--all-workflows` | full set installed | ✅ |
| D | iOS app, no CI | no `docs.yml` / `validate-release.yml` | ✅ |
| E | own `ci.yml` + generated `quality.yml` | `quality.yml` refreshed, nothing added | ✅ |
| F | project-owned `quality.yml` (no header) | kept verbatim, nothing added | ✅ |

Case A caught the incomplete first fix, and case F drove the decision to judge ownership by header rather than filename.

`swiftc -typecheck` on `arcdevtools-setup` exits 0.

## ♻️ ARCKnowledge → v2.16.0

Dead-link cleanup (30 → 0, verified with the same `markdown-link-check` config ARC CI uses) and the `arc-testflight` agent alignment. Also the first ARCKnowledge tag containing the `AGENTS.md` Xcode Tooling Policy section and `Quality/api-keys.md`, which had reached `main` without a version. The pointer moves from a `develop` commit to the tagged `v2.16.0` on `main`.

## Follow-up, not in this PR

The five packages already carrying the broken `docs.yml` and `validate-release.yml` need those removed. Handled with the package rollout.