### PR TITLE
[BUGFIX] pre-push: resolve pinned tools at depth 4 + protect main/develop

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -17,6 +17,49 @@ if [ "$SKIP_HOOKS" = "1" ]; then
     exit 0
 fi
 
+
+# ---------------------------------------------------------------------------
+# Protected branch guard
+#
+# main and develop must never be deleted or force-pushed. GitHub branch
+# protection and rulesets are unavailable on free personal accounts with
+# private repos, so this is the backstop.
+#
+# Covers pushes from a clone only — it cannot stop the "Delete branch" button
+# the GitHub web UI offers after a merge.
+#
+# Deliberate override: PROTECTED_BRANCH_OVERRIDE=1 git push ...
+# ---------------------------------------------------------------------------
+__arc_protected="main develop"
+__arc_zero="0000000000000000000000000000000000000000"
+__arc_blocked=0
+
+while read -r _arc_lref __arc_lsha __arc_rref __arc_rsha; do
+    [ -z "${__arc_rref:-}" ] && continue
+    __arc_branch="${__arc_rref#refs/heads/}"
+    for __arc_p in $__arc_protected; do
+        [ "$__arc_branch" = "$__arc_p" ] || continue
+        if [ "$__arc_lsha" = "$__arc_zero" ]; then
+            echo "🛑 Refusing to DELETE protected branch '$__arc_branch'."
+            __arc_blocked=1
+        elif [ "$__arc_rsha" != "$__arc_zero" ] && ! git merge-base --is-ancestor "$__arc_rsha" "$__arc_lsha" 2>/dev/null; then
+            echo "🛑 Refusing NON-FAST-FORWARD push to protected branch '$__arc_branch' (would discard remote commits)."
+            __arc_blocked=1
+        fi
+    done
+done
+
+if [ "$__arc_blocked" -eq 1 ]; then
+    if [ "${PROTECTED_BRANCH_OVERRIDE:-0}" = "1" ]; then
+        echo "⚠️  PROTECTED_BRANCH_OVERRIDE=1 set — allowing anyway."
+    else
+        echo ""
+        echo "   main and develop must never be deleted or rewritten."
+        echo "   If genuinely intended: PROTECTED_BRANCH_OVERRIDE=1 git push ..."
+        exit 1
+    fi
+fi
+
 echo "🚀 Pre-push: Running quality checks..."
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -25,7 +68,7 @@ cd "$REPO_ROOT" || exit 1
 # Resolve the *pinned* SwiftLint/SwiftFormat so local results match CI.
 # The submodule is usually at ARCDevTools/, but projects may nest it
 # (e.g. Tools/ARCDevTools), so locate it rather than hardcoding the path.
-ARC_TOOL_ENV="$(find "$REPO_ROOT" -maxdepth 3 -path '*/ARCDevTools/scripts/tool-env.sh' -print -quit 2>/dev/null)"
+ARC_TOOL_ENV="$(find "$REPO_ROOT" -maxdepth 4 -path '*/ARCDevTools/scripts/tool-env.sh' -print -quit 2>/dev/null)"
 if [ -n "$ARC_TOOL_ENV" ]; then
     # shellcheck source=/dev/null
     . "$ARC_TOOL_ENV"


### PR DESCRIPTION
Two fixes to `hooks/pre-push`.

## 1. Pinned tool resolution was silently failing (the real bug)

The find that locates `scripts/tool-env.sh` used `-maxdepth 3`:

```bash
find "$REPO_ROOT" -maxdepth 3 -path '*/ARCDevTools/scripts/tool-env.sh'
```

That only matches when the submodule sits at `<repo>/ARCDevTools/`. FavRes-iOS nests it at `Tools/ARCDevTools/`, putting the script at depth 4 — so the find returned nothing and the hook fell through to `command -v swiftlint`, with no warning.

On that machine `PATH` resolved to **SwiftLint 0.49.1**, which predates Swift 5.9 `switch` expressions and emits false `switch_case_alignment` violations against correct code:

```swift
let symbols: [String] = switch explainer {
case .aiRecommender: [...]
```

The pinned **0.65.0** reports the same file clean. Net effect: valid pushes blocked, and the entire point of pinning — local results matching CI — quietly defeated. Same class of trap as the SwiftFormat 0.60.1-vs-0.62.1 issue.

Fixed by bumping to `-maxdepth 4`.

## 2. Protected branch guard

`main` and `develop` can no longer be deleted or force-pushed:

```
🛑 Refusing to DELETE protected branch 'develop'.
```

Context: GitHub branch protection and rulesets return 403 on free personal accounts with private repos, so there is no server-side option. `develop` was deleted for real on ARCLabsStudio-Web when a release PR merged.

Override for deliberate cases (e.g. resyncing a diverged develop): `PROTECTED_BRANCH_OVERRIDE=1 git push ...`

**Limitation, stated plainly:** this covers pushes from a clone only. It cannot stop the "Delete branch" button the GitHub web UI offers after merging a PR — which is the vector that actually caused the deletion.

## Verification

- `bash -n hooks/pre-push` clean
- Guard tested live in both FavRes-iOS and ARCLabsStudio-Web (spliced locally): blocks `--delete` and non-fast-forward pushes to `main`/`develop`, allows normal feature-branch pushes, and honours the override
- Depth fix verified: `find -maxdepth 3` returns nothing in FavRes-iOS, `-maxdepth 4` returns `./Tools/ARCDevTools/scripts/tool-env.sh`

After this merges, consuming repos pick it up via submodule bump + `make hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)